### PR TITLE
Initial implementation: Generate PrometheusRules using Sloth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /_public
 
 # Additional entries
+/sloth-*

--- a/.sync.yml
+++ b/.sync.yml
@@ -9,3 +9,8 @@
 .github/workflows/test.yaml:
   test_makeTarget: test -e instance=${{ matrix.instance }}
   goldenTest_makeTarget: golden-diff -e instance=${{ matrix.instance }}
+
+.gitignore:
+  additionalEntries:
+    # Downloaded sloth cli
+    - /sloth-*

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,4 +1,13 @@
 parameters:
   openshift4_slos:
     =_metadata: {}
-    namespace: syn-openshift4-slos
+    namespace: appuio-openshift4-slos
+
+    images:
+      # The image will not be used. It is here so Renovate can update the Sloth version.
+      sloth:
+        registry: ghcr.io
+        image: slok/sloth
+        tag: v0.10.0
+
+    specs: {}

--- a/class/openshift4-slos.yml
+++ b/class/openshift4-slos.yml
@@ -5,7 +5,41 @@ parameters:
           - ${_base_directory}/component/app.jsonnet
         input_type: jsonnet
         output_path: apps/
+
+      - input_paths:
+          - ${_base_directory}/component/sloth-input.jsonnet
+        input_type: jsonnet
+        output_path: ${_base_directory}/sloth-input
+        output_type: yaml
+
+      - input_type: external
+        input_paths:
+          - /bin/mkdir
+        args:
+          - -p
+          - ${_base_directory}/sloth-output
+        output_path: .
+      - input_type: external
+        input_paths:
+          - openshift4-slos/run-sloth
+        output_path: .
+        env_vars:
+          SLOTH_VERSION: ${openshift4_slos:images:sloth:tag}
+        args:
+          - generate
+          - -i
+          - ${_base_directory}/sloth-input
+          - -o
+          - ${_base_directory}/sloth-output
+
       - input_paths:
           - ${_base_directory}/component/main.jsonnet
         input_type: jsonnet
         output_path: openshift4-slos/
+
+      # Cleanup
+      - input_paths:
+          - ${_base_directory}/sloth-input
+          - ${_base_directory}/sloth-output
+        input_type: remove
+        output_path: .

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -1,4 +1,5 @@
 // main template for openshift4-slos
+local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
@@ -6,5 +7,13 @@ local inv = kap.inventory();
 local params = inv.parameters.openshift4_slos;
 
 // Define outputs below
-{
-}
+local mergeSpec = function(name, spec)
+  local slothRendered = std.parseJson(kap.yaml_load('sloth-output/%s.yaml' % name));
+  local metadata = com.makeMergeable(std.get(spec, 'metadata', {}));
+  kube._Object('monitoring.coreos.com/v1', 'PrometheusRule', name) {
+    metadata+: metadata,
+    spec: slothRendered,
+  }
+;
+
+std.mapWithKey(mergeSpec, params.specs)

--- a/component/sloth-input.jsonnet
+++ b/component/sloth-input.jsonnet
@@ -1,0 +1,24 @@
+// main template for openshift4-slos
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.openshift4_slos;
+
+local specs = std.mapWithKey(
+  function(name, obj)
+    obj {
+      sloth_input+: {
+        [if std.objectHas(obj.sloth_input, '_slos') then 'slos']+: [
+          obj.sloth_input._slos[name] { name: name }
+          for name in std.objectFields(obj.sloth_input._slos)
+        ],
+      },
+    },
+  params.specs
+);
+
+// Define outputs below
+std.mapWithKey(function(name, obj) obj.sloth_input, specs)

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -6,14 +6,149 @@ The parent key for all of the following parameters is `openshift4_slos`.
 
 [horizontal]
 type:: string
-default:: `syn-openshift4-slos`
+default:: `appuio-openshift4-slos`
 
-The namespace in which to deploy this component.
+The default namespace for ArgoCD to fall back to.
+
+
+== `images`
+
+[horizontal]
+type:: dictionary
+
+The images to use for this component.
+
+[INFO]
+This component current doesn't deploy any active components.
+The only manifests produced are `PrometheusRule`s.
+
+
+== `images.sloth`
+
+[horizontal]
+type:: dictionary
+
+Allows Renovate to create version upgrade PRs.
+The Sloth version can be overridden by the `tag` parameter.
+
+
+== `specs`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+
+The SLO definition that are passed to Sloth.
+The key is used as the name of the resulting PrometheusRule.
+It must be a valid Kubernetes name.
+
+
+=== `specs.NAME.metadata`
+
+[horizontal]
+type:: dictionary
+example::
++
+[source,yaml]
+----
+metadata:
+  namespace: my-important-service
+  labels:
+    prometheus: apps
+----
+
+The metadata applied to the PrometheusRule manifest.
+The name is derived from the name of the parent dictionary.
+
+
+=== `specs.NAME.sloth_input`
+
+[horizontal]
+type:: dictionary
+example::
++
+[source,yaml]
+----
+sloth_input:
+  version: "prometheus/v1"
+  service: "myservice"
+  labels:
+    owner: "myteam"
+    repo: "myorg/myservice"
+    tier: "2"
+  _slos:
+    # We allow failing (5xx and 429) 1 request every 1000 requests (99.9%).
+    requests-availability:
+      objective: 99.9
+      description: "Common SLO based on availability for HTTP request responses."
+      sli:
+        events:
+          error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+          total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+      alerting:
+        name: MyServiceHighErrorRate
+        labels:
+          category: "availability"
+        annotations:
+          # Overwrite default Sloth SLO alert summmary on ticket and page alerts.
+          summary: "High error rate on 'myservice' requests responses"
+        page_alert:
+          labels:
+            severity: pageteam
+            routing_key: myteam
+        ticket_alert:
+          labels:
+            severity: "slack"
+            slack_channel: "#alerts-myteam"
+----
+
+The input for sloth to generate the `PrometheusRule.spec`.
+See https://sloth.dev/introduction/[Sloth introduction] for more information.
+
+The `slos` can be passed as either an array or as a dictionary with the key `_slos`.
+This is done to allow easier modification of the SLOs from the Project Syn hierarchy.
 
 
 == Example
 
 [source,yaml]
 ----
-namespace: example-namespace
+namespace: appuio-openshift4-slos
+specs:
+  getting-started:
+    metadata:
+      namespace: my-important-service
+      labels:
+        prometheus: apps
+    sloth_input:
+      version: "prometheus/v1"
+      service: "myservice"
+      labels:
+        owner: "myteam"
+        repo: "myorg/myservice"
+        tier: "2"
+      _slos:
+        # We allow failing (5xx and 429) 1 request every 1000 requests (99.9%).
+        requests-availability:
+          objective: 99.9
+          description: "Common SLO based on availability for HTTP request responses."
+          sli:
+            events:
+              error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+              total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+          alerting:
+            name: MyServiceHighErrorRate
+            labels:
+              category: "availability"
+            annotations:
+              # Overwrite default Sloth SLO alert summmary on ticket and page alerts.
+              summary: "High error rate on 'myservice' requests responses"
+            page_alert:
+              labels:
+                severity: pageteam
+                routing_key: myteam
+            ticket_alert:
+              labels:
+                severity: "slack"
+                slack_channel: "#alerts-myteam"
 ----

--- a/run-sloth
+++ b/run-sloth
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -eu
+
+basedir=$(dirname "$0")
+version="${SLOTH_VERSION:-v0.10.0}"
+
+ensure_sloth () {
+  set -eu
+
+  local dir="$1"
+  # Version with leading `v`.
+  local version="$2"
+
+  local arch
+  arch=$(uname -m)
+  case $arch in
+    aarch64|arm64) arch="arm64";;
+    x86_64|amd64) arch="amd64";;
+    *)
+      >&2 echo "Unsupported arch: $arch"
+      exit 5
+    ::
+  esac
+
+  local os
+  os=$(uname -s)
+  case $os in
+    Linux) os="linux";;
+    Darwin) os="darwin";;
+    *)
+      >&2 echo "Unsupported os: $os"
+      exit 5
+    ::
+  esac
+
+  if [ ! -x "${dir}/sloth-${version}-${os}-${arch}" ]; then
+    download_sloth "${dir}" "${version}" "${os}" "${arch}"
+  else
+    >&2 echo "sloth-${version}-${os}-${arch} already installed"
+  fi
+
+  echo "${dir}/sloth-${version}-${os}-${arch}"
+}
+
+download_sloth () {
+  set -eu
+
+  local dir="$1"
+  local version="$2"
+  local os="$3"
+  local arch="$4"
+
+  local url="https://github.com/slok/sloth/releases/download/${version}/sloth-${os}-${arch}"
+
+  >&2 echo "Downloading sloth-${version}-${os}-${arch} from ${url}"
+
+  curl -fsSLo "${dir}/sloth-${version}-${os}-${arch}" "${url}"
+  chmod +x "${dir}/sloth-${version}-${os}-${arch}"
+
+  >&2 echo "sloth-${version}-${os}-${arch} successfully installed"
+}
+
+sloth=$(ensure_sloth "$basedir" "$version")
+
+"$sloth" "$@"

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,3 +1,39 @@
 # Overwrite parameters here
 
-# parameters: {...}
+parameters:
+  openshift4_slos:
+    specs:
+      getting-started:
+        metadata:
+          namespace: getting-started-ns
+        sloth_input:
+          version: "prometheus/v1"
+          service: "myservice"
+          labels:
+            owner: "myteam"
+            repo: "myorg/myservice"
+            tier: "2"
+          _slos:
+            # We allow failing (5xx and 429) 1 request every 1000 requests (99.9%).
+            requests-availability:
+              objective: 99.9
+              description: "Common SLO based on availability for HTTP request responses."
+              sli:
+                events:
+                  error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+                  total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+              alerting:
+                name: MyServiceHighErrorRate
+                labels:
+                  category: "availability"
+                annotations:
+                  # Overwrite default Sloth SLO alert summmary on ticket and page alerts.
+                  summary: "High error rate on 'myservice' requests responses"
+                page_alert:
+                  labels:
+                    severity: pageteam
+                    routing_key: myteam
+                ticket_alert:
+                  labels:
+                    severity: "slack"
+                    slack_channel: "#alerts-myteam"

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/getting-started.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/getting-started.yaml
@@ -1,0 +1,265 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: getting-started
+  name: getting-started
+  namespace: getting-started-ns
+spec:
+  groups:
+    - name: sloth-slo-sli-recordings-myservice-requests-availability
+      rules:
+        - expr: '(sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
+
+            /
+
+            (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+
+            '
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            sloth_window: 5m
+            tier: '2'
+          record: slo:sli_error:ratio_rate5m
+        - expr: '(sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
+
+            /
+
+            (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+
+            '
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            sloth_window: 30m
+            tier: '2'
+          record: slo:sli_error:ratio_rate30m
+        - expr: '(sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
+
+            /
+
+            (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+
+            '
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            sloth_window: 1h
+            tier: '2'
+          record: slo:sli_error:ratio_rate1h
+        - expr: '(sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
+
+            /
+
+            (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+
+            '
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            sloth_window: 2h
+            tier: '2'
+          record: slo:sli_error:ratio_rate2h
+        - expr: '(sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
+
+            /
+
+            (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+
+            '
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            sloth_window: 6h
+            tier: '2'
+          record: slo:sli_error:ratio_rate6h
+        - expr: '(sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
+
+            /
+
+            (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+
+            '
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            sloth_window: 1d
+            tier: '2'
+          record: slo:sli_error:ratio_rate1d
+        - expr: '(sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
+
+            /
+
+            (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+
+            '
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            sloth_window: 3d
+            tier: '2'
+          record: slo:sli_error:ratio_rate3d
+        - expr: 'sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+            sloth_service="myservice", sloth_slo="requests-availability"}[30d])
+
+            / ignoring (sloth_window)
+
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+            sloth_service="myservice", sloth_slo="requests-availability"}[30d])
+
+            '
+          labels:
+            sloth_window: 30d
+          record: slo:sli_error:ratio_rate30d
+    - name: sloth-slo-meta-recordings-myservice-requests-availability
+      rules:
+        - expr: vector(0.9990000000000001)
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            tier: '2'
+          record: slo:objective:ratio
+        - expr: vector(1-0.9990000000000001)
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            tier: '2'
+          record: slo:error_budget:ratio
+        - expr: vector(30)
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            tier: '2'
+          record: slo:time_period:days
+        - expr: 'slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+            sloth_service="myservice", sloth_slo="requests-availability"}
+
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+
+            slo:error_budget:ratio{sloth_id="myservice-requests-availability", sloth_service="myservice",
+            sloth_slo="requests-availability"}
+
+            '
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            tier: '2'
+          record: slo:current_burn_rate:ratio
+        - expr: 'slo:sli_error:ratio_rate30d{sloth_id="myservice-requests-availability",
+            sloth_service="myservice", sloth_slo="requests-availability"}
+
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+
+            slo:error_budget:ratio{sloth_id="myservice-requests-availability", sloth_service="myservice",
+            sloth_slo="requests-availability"}
+
+            '
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            tier: '2'
+          record: slo:period_burn_rate:ratio
+        - expr: 1 - slo:period_burn_rate:ratio{sloth_id="myservice-requests-availability",
+            sloth_service="myservice", sloth_slo="requests-availability"}
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            tier: '2'
+          record: slo:period_error_budget_remaining:ratio
+        - expr: vector(1)
+          labels:
+            owner: myteam
+            repo: myorg/myservice
+            sloth_id: myservice-requests-availability
+            sloth_mode: cli-gen-prom
+            sloth_objective: '99.9'
+            sloth_service: myservice
+            sloth_slo: requests-availability
+            sloth_spec: prometheus/v1
+            sloth_version: v0.10.0
+            tier: '2'
+          record: sloth_slo_info
+    - name: sloth-slo-alerts-myservice-requests-availability
+      rules:
+        - alert: MyServiceHighErrorRate
+          annotations:
+            summary: High error rate on 'myservice' requests responses
+            title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: "(\n    (slo:sli_error:ratio_rate5m{sloth_id=\"myservice-requests-availability\"\
+            , sloth_service=\"myservice\", sloth_slo=\"requests-availability\"} >\
+            \ (14.4 * 0.0009999999999999432))\n    and ignoring (sloth_window)\n \
+            \   (slo:sli_error:ratio_rate1h{sloth_id=\"myservice-requests-availability\"\
+            , sloth_service=\"myservice\", sloth_slo=\"requests-availability\"} >\
+            \ (14.4 * 0.0009999999999999432))\n)\nor ignoring (sloth_window)\n(\n\
+            \    (slo:sli_error:ratio_rate30m{sloth_id=\"myservice-requests-availability\"\
+            , sloth_service=\"myservice\", sloth_slo=\"requests-availability\"} >\
+            \ (6 * 0.0009999999999999432))\n    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate6h{sloth_id=\"\
+            myservice-requests-availability\", sloth_service=\"myservice\", sloth_slo=\"\
+            requests-availability\"} > (6 * 0.0009999999999999432))\n)\n"
+          labels:
+            category: availability
+            routing_key: myteam
+            severity: pageteam
+            sloth_severity: page
+        - alert: MyServiceHighErrorRate
+          annotations:
+            summary: High error rate on 'myservice' requests responses
+            title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: "(\n    (slo:sli_error:ratio_rate2h{sloth_id=\"myservice-requests-availability\"\
+            , sloth_service=\"myservice\", sloth_slo=\"requests-availability\"} >\
+            \ (3 * 0.0009999999999999432))\n    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate1d{sloth_id=\"\
+            myservice-requests-availability\", sloth_service=\"myservice\", sloth_slo=\"\
+            requests-availability\"} > (3 * 0.0009999999999999432))\n)\nor ignoring\
+            \ (sloth_window)\n(\n    (slo:sli_error:ratio_rate6h{sloth_id=\"myservice-requests-availability\"\
+            , sloth_service=\"myservice\", sloth_slo=\"requests-availability\"} >\
+            \ (1 * 0.0009999999999999432))\n    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate3d{sloth_id=\"\
+            myservice-requests-availability\", sloth_service=\"myservice\", sloth_slo=\"\
+            requests-availability\"} > (1 * 0.0009999999999999432))\n)\n"
+          labels:
+            category: availability
+            severity: slack
+            slack_channel: '#alerts-myteam'
+            sloth_severity: ticket


### PR DESCRIPTION
Passes the Sloth config from `.specs` to Sloth and wraps the output of Sloth in a PrometheusRule object.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
