### PR TITLE
Add SLO for Storage Operations

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -23,6 +23,12 @@ parameters:
       ticket_labels:
         severity: warning
 
+    slos:
+      storage:
+        csi-operations:
+          enabled: true
+          objective: 99.5
+
     specs: {}
 
     blackbox_exporter:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -28,6 +28,9 @@ parameters:
         csi-operations:
           enabled: true
           objective: 99.5
+          _sli:
+            volume_plugin: "kubernetes.io/csi.+"
+            operation_name: ".+"
 
     specs: {}
 

--- a/component/slos.libsonnet
+++ b/component/slos.libsonnet
@@ -17,8 +17,8 @@ local defaultSlos = {
           description: 'SLO based on number of failed csi operations',
           sli: {
             events: {
-              error_query: 'sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[{{.window}}]))',
-              total_query: 'sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[{{.window}}]))',
+              error_query: 'sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"%s",operation_name=~"%s",status="fail-unknown"}[{{.window}}]))' % [ config['csi-operations']._sli.volume_plugin, config['csi-operations']._sli.operation_name ],
+              total_query: 'sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"%s",operation_name=~"%s"}[{{.window}}]))' % [ config['csi-operations']._sli.volume_plugin, config['csi-operations']._sli.operation_name ],
             },
           },
           alerting: {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -56,7 +56,7 @@ The SLO can be disabled by setting `enabled` to false.
 You can configure which volume plugins or storage operations are considered for the SLO by setting `_sli.volume_plugin`  or `_sli.operation_name` respectively.
 The fields can contain an arbitrary https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors[PromQL regex label matcher].
 
-Any field is added directly to the `slo` input for sloth.
+Any additional field is added directly to the `slo` input for sloth.
 
 NOTE: Look at xref:runbooks/storage.adoc#csi-operations[the runbook] for an explanation of this SLO.
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -28,6 +28,38 @@ Sloth isn't actually deployed to the cluster, but used to render `PrometheusRule
 The entry in `images` allows Renovate to create version upgrade PRs.
 The Sloth version can be overridden by the `tag` parameter.
 
+== `slos`
+[horizontal]
+type:: dictionary
+
+The configuration option of all default SLOs for the APPUiO Managed OpenShift product.
+
+=== `slos.storage.csi-operations`
+[horizontal]
+type:: dictionary
+default::
+
+[source,yaml]
+----
+csi-operations:
+  enabled: true
+  objective: 99.5
+  _sli:
+    volume_plugin: "kubernetes.io/csi.+"
+    operation_name: ".+"
+----
+
+The configuration for the csi-operations SLO.
+
+The SLO can be disabled by setting `enabled` to false.
+
+You can configure which volume plugins or storage operations are considered for the SLO by setting `_sli.volume_plugin`  or `_sli.operation_name` respectively.
+The fields can contain an arbitrary https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors[PromQL regex label matcher].
+
+Any field is added directly to the `slo` input for sloth.
+
+NOTE: Look at xref:runbooks/storage.adoc#csi-operations[the runbook] for an explanation of this SLO.
+
 == `alerting`
 
 [horizontal]

--- a/docs/modules/ROOT/pages/runbooks/storage.adoc
+++ b/docs/modules/ROOT/pages/runbooks/storage.adoc
@@ -13,7 +13,8 @@ The error rate is a general indicator of the health of the storage provider, but
 There are two types of alerts that fire if we expect to miss the configured SLO objective.
 
 * A ticket alert means that the error rate is slightly higher than the objective.
-If we don't intervene we can expect to miss the objective, however no immediate, urgent action is necessary.
+If we don't intervene at some point after receiving this alert, we can expect to miss the objective.
+However no immediate, urgent action is necessary.
 A ticket alert should have a label `severity: warning`.
 * A page alert means that the error rate is significantly higher than the objective.
 Immediate action is necessary to not miss the objective.
@@ -38,7 +39,7 @@ With these you should be able to narrow down the issue:
 Look at the logs of that csi provider to investigate further.
 * If they have the same `node` label it might be an issue with one specific node.
 * If all have the same `operation_name` label then there is an issue with this specific operation.
-For `volume_attach` and `volume_detach` you can see if the controller-manager logs anything useful.
+For `volume_attach` and `volume_detach` check if the controller-manager logs anything useful.
 For all other operations the kubelet might log more information.
 * If all time series have the same `job` label it might be an issue with the kubelet or the controller-manager, look at the respective logs.
 
@@ -51,13 +52,13 @@ If you had to debug this alert, please consider adding any insight, tips, or cod
 
 === icon:wrench[] Tune
 
-If this alert isn't actionable, noisy, or was raised too late you might want to tune the SLO.
+If this alert isn't actionable, noisy, or was raised too late you may want to tune the SLO.
 
-Through the component parameters you have the option tune the SLO.
-You can modify the objective, disable the page or ticket alert, restrict the SLO to certain storage operations or volume plugins, or outright disable the complete SLO.
+You have the option tune the SLO through the component parameters.
+You can modify the objective, disable the page or ticket alert, restrict the SLO to certain storage operations or volume plugins, or completely disable the SLO.
 
-In the example below will set the SLO set the objective to 99.25%, disable the page alert, and only consider the Ceph storage provider.
-This means this SLO won't alert on-call anymore and won't alert if there are issues with other volume plugins.
+The example below will set the SLO set the objective to 99.25%, disable the page alert, and only consider the Syn-managed CephFS storage provider.
+This means this SLO won't alert on-call anymore and won't alert if there are issues with CSI plugins other than the Syn-managed CephFS CSI plugin.
 
 [source,yaml]
 ----

--- a/docs/modules/ROOT/pages/runbooks/storage.adoc
+++ b/docs/modules/ROOT/pages/runbooks/storage.adoc
@@ -1,0 +1,77 @@
+= Storage SLOs
+
+include::partial$runbooks/contribution_note.adoc[]
+
+[[csi-operations]]
+== Storage Operations
+
+=== icon:glasses[] Overview
+
+This SLO measures the percentage of failed storage operations, reported by kubelets and the controller-manager.
+The error rate is a general indicator of the health of the storage provider, but might not show you the root cause of the issue.
+
+There are two types of alerts that fire if we expect to miss the configured SLO objective.
+
+* A ticket alert means that the error rate is slightly higher than the objective.
+If we don't intervene we can expect to miss the objective, however no immediate, urgent action is necessary.
+A ticket alert should have a label `severity: warning`.
+* A page alert means that the error rate is significantly higher than the objective.
+Immediate action is necessary to not miss the objective.
+A page alert should have a label `severity: critical` and should page on-call.
+
+=== icon:bug[] Steps for debugging
+
+A high storage operations error rate can have many root causes.
+To narrow down the issue we first need to find out which operations and which providers are effected.
+
+Connect to the Prometheus on the cluster and run the following query:
+
+[source,promql]
+----
+sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+", status="fail-unknown"}[5m])) by (job, operation_name, volume_plugin, node)
+----
+
+This should return one or more time series.
+With these you should be able to narrow down the issue:
+
+* If all time series have the same `volume_plugin` label the issue is most likely caused by that provider.
+Look at the logs of that csi provider to investigate further.
+* If they have the same `node` label it might be an issue with one specific node.
+* If all have the same `operation_name` label then there is an issue with this specific operation.
+For `volume_attach` and `volume_detach` you can see if the controller-manager logs anything useful.
+For all other operations the kubelet might log more information.
+* If all time series have the same `job` label it might be an issue with the kubelet or the controller-manager, look at the respective logs.
+
+This should give you a starting point to investigate the root cause.
+You should also check if there are other, related firing alerts and create/delete a test PVC to properly assess the impact of this alert.
+
+NOTE: We don't have a lot of experience with this alert yet.
+If you had to debug this alert, please consider adding any insight, tips, or code snippets you gained to this runbook.
+
+
+=== icon:wrench[] Tune
+
+If this alert isn't actionable, noisy, or was raised too late you might want to tune the SLO.
+
+Through the component parameters you have the option tune the SLO.
+You can modify the objective, disable the page or ticket alert, restrict the SLO to certain storage operations or volume plugins, or outright disable the complete SLO.
+
+In the example below will set the SLO set the objective to 99.25%, disable the page alert, and only consider the Ceph storage provider.
+This means this SLO won't alert on-call anymore and won't alert if there are issues with other volume plugins.
+
+[source,yaml]
+----
+slos:
+  storage:
+    csi-operations:
+      objective: 99.25
+      _sli:
+        volume_plugin: "kubernetes.io/csi:syn-rook-ceph-operator.cephfs.csi.ceph.com"
+      alerting:
+        page_alert:
+          enabled: false
+
+----
+
+WARNING: Diabling the SLO or changing the objective will also impact the SLO dashboard and SLA reporting.
+Only disable SLOs if they're not relevant, not if the alerts are noisy.

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,2 +1,6 @@
 * xref:index.adoc[Home]
 * xref:references/parameters.adoc[Parameters]
+
+* SLO Runbooks
+** xref:runbooks/storage.adoc[Storage SLOs]
+

--- a/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
+++ b/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
@@ -1,0 +1,5 @@
+[NOTE]
+====
+Please consider opening a PR to improve this runbook if you gain new information about causes of the alert, or how to debug or resolve the alert.
+Click "Edit this Page" in the top right corner to create a PR directly on GitHub.
+====

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/storage.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/storage.yaml
@@ -9,11 +9,11 @@ spec:
   groups:
     - name: sloth-slo-sli-recordings-storage-csi-operations
       rules:
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[5m])))
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[5m])))
 
             /
 
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[5m])))
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[5m])))
 
             '
           labels:
@@ -22,11 +22,11 @@ spec:
             sloth_slo: csi-operations
             sloth_window: 5m
           record: slo:sli_error:ratio_rate5m
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[30m])))
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[30m])))
 
             /
 
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[30m])))
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[30m])))
 
             '
           labels:
@@ -35,11 +35,11 @@ spec:
             sloth_slo: csi-operations
             sloth_window: 30m
           record: slo:sli_error:ratio_rate30m
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[1h])))
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[1h])))
 
             /
 
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[1h])))
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[1h])))
 
             '
           labels:
@@ -48,11 +48,11 @@ spec:
             sloth_slo: csi-operations
             sloth_window: 1h
           record: slo:sli_error:ratio_rate1h
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[2h])))
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[2h])))
 
             /
 
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[2h])))
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[2h])))
 
             '
           labels:
@@ -61,11 +61,11 @@ spec:
             sloth_slo: csi-operations
             sloth_window: 2h
           record: slo:sli_error:ratio_rate2h
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[6h])))
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[6h])))
 
             /
 
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[6h])))
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[6h])))
 
             '
           labels:
@@ -74,11 +74,11 @@ spec:
             sloth_slo: csi-operations
             sloth_window: 6h
           record: slo:sli_error:ratio_rate6h
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[1d])))
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[1d])))
 
             /
 
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[1d])))
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[1d])))
 
             '
           labels:
@@ -87,11 +87,11 @@ spec:
             sloth_slo: csi-operations
             sloth_window: 1d
           record: slo:sli_error:ratio_rate1d
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[3d])))
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[3d])))
 
             /
 
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[3d])))
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[3d])))
 
             '
           labels:

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/storage.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/storage.yaml
@@ -1,0 +1,221 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: storage
+  name: storage
+spec:
+  groups:
+    - name: sloth-slo-sli-recordings-storage-csi-operations
+      rules:
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[5m])))
+
+            /
+
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[5m])))
+
+            '
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+            sloth_window: 5m
+          record: slo:sli_error:ratio_rate5m
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[30m])))
+
+            /
+
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[30m])))
+
+            '
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+            sloth_window: 30m
+          record: slo:sli_error:ratio_rate30m
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[1h])))
+
+            /
+
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[1h])))
+
+            '
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+            sloth_window: 1h
+          record: slo:sli_error:ratio_rate1h
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[2h])))
+
+            /
+
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[2h])))
+
+            '
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+            sloth_window: 2h
+          record: slo:sli_error:ratio_rate2h
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[6h])))
+
+            /
+
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[6h])))
+
+            '
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+            sloth_window: 6h
+          record: slo:sli_error:ratio_rate6h
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[1d])))
+
+            /
+
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[1d])))
+
+            '
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+            sloth_window: 1d
+          record: slo:sli_error:ratio_rate1d
+        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",status="fail-unknown"}[3d])))
+
+            /
+
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+"}[3d])))
+
+            '
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+            sloth_window: 3d
+          record: slo:sli_error:ratio_rate3d
+        - expr: 'sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="storage-csi-operations",
+            sloth_service="storage", sloth_slo="csi-operations"}[30d])
+
+            / ignoring (sloth_window)
+
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="storage-csi-operations",
+            sloth_service="storage", sloth_slo="csi-operations"}[30d])
+
+            '
+          labels:
+            sloth_window: 30d
+          record: slo:sli_error:ratio_rate30d
+    - name: sloth-slo-meta-recordings-storage-csi-operations
+      rules:
+        - expr: vector(0.995)
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+          record: slo:objective:ratio
+        - expr: vector(1-0.995)
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+          record: slo:error_budget:ratio
+        - expr: vector(30)
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+          record: slo:time_period:days
+        - expr: 'slo:sli_error:ratio_rate5m{sloth_id="storage-csi-operations", sloth_service="storage",
+            sloth_slo="csi-operations"}
+
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+
+            slo:error_budget:ratio{sloth_id="storage-csi-operations", sloth_service="storage",
+            sloth_slo="csi-operations"}
+
+            '
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+          record: slo:current_burn_rate:ratio
+        - expr: 'slo:sli_error:ratio_rate30d{sloth_id="storage-csi-operations", sloth_service="storage",
+            sloth_slo="csi-operations"}
+
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+
+            slo:error_budget:ratio{sloth_id="storage-csi-operations", sloth_service="storage",
+            sloth_slo="csi-operations"}
+
+            '
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+          record: slo:period_burn_rate:ratio
+        - expr: 1 - slo:period_burn_rate:ratio{sloth_id="storage-csi-operations",
+            sloth_service="storage", sloth_slo="csi-operations"}
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_service: storage
+            sloth_slo: csi-operations
+          record: slo:period_error_budget_remaining:ratio
+        - expr: vector(1)
+          labels:
+            sloth_id: storage-csi-operations
+            sloth_mode: cli-gen-prom
+            sloth_objective: '99.5'
+            sloth_service: storage
+            sloth_slo: csi-operations
+            sloth_spec: prometheus/v1
+            sloth_version: v0.10.0
+          record: sloth_slo_info
+    - name: sloth-slo-alerts-storage-csi-operations
+      rules:
+        - alert: StorageOperationHighErrorRate
+          annotations:
+            runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/storage.html#csi-operations
+            summary: High storage operation error rate
+            title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: "(\n    (slo:sli_error:ratio_rate5m{sloth_id=\"storage-csi-operations\"\
+            , sloth_service=\"storage\", sloth_slo=\"csi-operations\"} > (14.4 * 0.005))\n\
+            \    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate1h{sloth_id=\"\
+            storage-csi-operations\", sloth_service=\"storage\", sloth_slo=\"csi-operations\"\
+            } > (14.4 * 0.005))\n)\nor ignoring (sloth_window)\n(\n    (slo:sli_error:ratio_rate30m{sloth_id=\"\
+            storage-csi-operations\", sloth_service=\"storage\", sloth_slo=\"csi-operations\"\
+            } > (6 * 0.005))\n    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate6h{sloth_id=\"\
+            storage-csi-operations\", sloth_service=\"storage\", sloth_slo=\"csi-operations\"\
+            } > (6 * 0.005))\n)\n"
+          labels:
+            severity: critical
+            sloth_severity: page
+            syn: 'true'
+            syn_component: openshift4-slos
+        - alert: StorageOperationHighErrorRate
+          annotations:
+            runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/storage.html#csi-operations
+            summary: High storage operation error rate
+            title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: "(\n    (slo:sli_error:ratio_rate2h{sloth_id=\"storage-csi-operations\"\
+            , sloth_service=\"storage\", sloth_slo=\"csi-operations\"} > (3 * 0.005))\n\
+            \    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate1d{sloth_id=\"\
+            storage-csi-operations\", sloth_service=\"storage\", sloth_slo=\"csi-operations\"\
+            } > (3 * 0.005))\n)\nor ignoring (sloth_window)\n(\n    (slo:sli_error:ratio_rate6h{sloth_id=\"\
+            storage-csi-operations\", sloth_service=\"storage\", sloth_slo=\"csi-operations\"\
+            } > (1 * 0.005))\n    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate3d{sloth_id=\"\
+            storage-csi-operations\", sloth_service=\"storage\", sloth_slo=\"csi-operations\"\
+            } > (1 * 0.005))\n)\n"
+          labels:
+            severity: warning
+            sloth_severity: ticket
+            syn: 'true'
+            syn_component: openshift4-slos


### PR DESCRIPTION
Adds the Storage operations SLO.

Introduced the top level `slos` key to more easily configure the default SLOs.

I wasn't able to write a very helpful runbook yet, as I'm not quite sure how the failure modes will look like yet and documentation on the different storage operations is very sparse.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
