### PR TITLE
Add Kubernetes API server SLOs

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -51,7 +51,18 @@ parameters:
         canary:
           enabled: true
           objective: 99.75
-
+      kubernetes_api:
+        requests:
+          enabled: true
+          objective: 99.9
+          _sli:
+            apiserver: "kube-apiserver"
+        canary:
+          enabled: true
+          objective: 99.9
+          _sli:
+            interval: 10s
+            timeout: 5s
 
     specs: {}
 

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -3,6 +3,7 @@ local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 
+local blackbox = import 'blackbox-exporter.libsonnet';
 local slo = import 'slos.libsonnet';
 
 local inv = kap.inventory();
@@ -14,7 +15,7 @@ local params = inv.parameters.openshift4_slos;
 local mergeSpec = function(name, spec)
   local slothRendered = std.parseJson(kap.yaml_load('%s/sloth-output/%s.yaml' % [ inv.parameters._base_directory, name ]));
   local metadata = com.makeMergeable(std.get(spec, 'metadata', {}));
-  kube._Object('monitoring.coreos.com/v1', 'PrometheusRule', name) {
+  kube._Object('monitoring.coreos.com/v1', 'PrometheusRule', kube.hyphenate(name)) {
     metadata+: metadata,
     spec: slothRendered,
   }
@@ -22,21 +23,6 @@ local mergeSpec = function(name, spec)
 
 local rules = std.mapWithKey(mergeSpec, slo.Specs);
 
-local probes = com.generateResources(
-  params.blackbox_exporter.probes,
-  function(name) kube._Object('monitoring.coreos.com/v1', 'Probe', name) {
-    metadata+: {
-      namespace: params.blackbox_exporter.namespace,
-    },
-    spec+: {
-      prober+: {
-        url: '%s.%s.svc:9115' % [ params.blackbox_exporter.name, params.blackbox_exporter.namespace ],
-        scheme: 'http',
-        path: '/probe',
-      },
-    },
-  }
-);
 
 local canaryImageStream = kube._Object('image.openshift.io/v1', 'ImageStream', 'canary') {
   local upstreamImage = params.images.canary,
@@ -106,9 +92,9 @@ local canary = kube._Object('monitoring.appuio.io/v1beta1', 'SchedulerCanary', '
       },
     },
   },
-  '20_probes': probes,
   '30_canaryImageStream': canaryImageStream,
   '30_canary': canary,
 }
-+ (import 'blackbox-exporter.libsonnet')
++ blackbox.deployment
++ blackbox.probes
 + rules

--- a/component/slos.libsonnet
+++ b/component/slos.libsonnet
@@ -121,7 +121,7 @@ local defaultSlos = {
             },
           },
           alerting: {
-            name: 'KubeApiServeFailure',
+            name: 'KubeApiServerFailure',
             annotations: {
               summary: 'Probes to Kubernetes API server fail',
             },

--- a/component/slos.libsonnet
+++ b/component/slos.libsonnet
@@ -90,6 +90,48 @@ local defaultSlos = {
       },
     },
   },
+  kubernetes_api: {
+    local config = params.slos.kubernetes_api,
+    sloth_input: {
+      version: 'prometheus/v1',
+      service: 'kubernetes_api',
+      _slos: {
+        requests: {
+          description: 'Kubernetes API Server SLO based on failed requests',
+          sli: {
+            events: {
+              error_query: 'sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"%s"}[{{.window}}]))' % [ config.requests._sli.apiserver ],
+              total_query: 'sum(rate(apiserver_request_total{apiserver=~"%s"}[{{.window}}]))' % [ config.requests._sli.apiserver ],
+            },
+          },
+          alerting: {
+            name: 'KubeApiServerHighErrorRate',
+            annotations: {
+              summary: 'High Kubernetes API server error rate',
+            },
+            page_alert: {},
+            ticket_alert: {},
+          },
+        } + config.requests,
+        canary: {
+          description: 'Kubernetes API Server SLO based on canary probes',
+          sli: {
+            raw: {
+              error_ratio_query: '1 - (sum_over_time(probe_success{job="probe-k8s-api"}[{{.window}}])/count_over_time(up{job="probe-k8s-api"}[{{.window}}]))',
+            },
+          },
+          alerting: {
+            name: 'KubeApiServeFailure',
+            annotations: {
+              summary: 'Probes to Kubernetes API server fail',
+            },
+            page_alert: {},
+            ticket_alert: {},
+          },
+        } + config.canary,
+      },
+    },
+  },
 };
 
 local patchSLO(slo) =

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -62,6 +62,60 @@ Any additional field is added directly to the `slo` input for sloth.
 
 NOTE: Look at xref:runbooks/storage.adoc#csi-operations[the runbook] for an explanation of this SLO.
 
+=== `slos.kubernetes_api.requests`
+
+[horizontal]
+type:: dictionary
+default::
++
+[source,yaml]
+----
+requests:
+  enabled: true
+  objective: 99.9
+  _sli:
+    apiserver: "kube-apiserver"
+----
+
+The configuration for the kubernetes API requests SLO.
+
+The SLO can be disabled by setting `enabled` to false.
+
+You can configure which API servers are actually considered for the SLO by setting `_sli.apiserver`.
+By default the SLO only consideres the Kubernetes API server and not the OpenShift API server.
+The field can contain an arbitrary https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors[PromQL regex label matcher].
+
+Any additional field is added directly to the `slo` input for sloth.
+
+NOTE: Look at xref:runbooks/kubernetes_api.adoc#requests[the runbook] for an explanation of this SLO.
+
+=== `slos.kubernetes_api.canary`
+
+[horizontal]
+type:: dictionary
+default::
++
+[source,yaml]
+----
+canary:
+  enabled: true
+  objective: 99.9
+  _sli:
+    interval: 10s
+    timeout: 5s
+----
+
+The configuration for the kubernetes API canary SLO.
+
+The SLO can be disabled by setting `enabled` to false.
+
+You can configure the probe interval and timeout by setting `_sli.interval` and `_sli.probe` respectively.
+Both parameters are in https://pkg.go.dev/time#ParseDuration[Go duration format] (for example `1m30s`).
+
+Any additional field is added directly to the `slo` input for sloth.
+
+NOTE: Look at xref:runbooks/kubernetes_api.adoc#canary[the runbook] for an explanation of this SLO.
+
 === `slos.workload-schedulability.canary`
 
 [horizontal]

--- a/docs/modules/ROOT/pages/runbooks/kubernetes_api.adoc
+++ b/docs/modules/ROOT/pages/runbooks/kubernetes_api.adoc
@@ -1,0 +1,182 @@
+= Kubernetes API SLOs
+
+include::partial$runbooks/contribution_note.adoc[]
+
+[[requests]]
+== API Requests
+
+=== icon:glasses[] Overview
+
+This SLO measures the percentage of valid, well structured Kubernetes API requets that fail.
+The error rate is a general indicator of the health of the API server, but might not show you the root cause of the issue.
+
+include::partial$runbooks/alert_types.adoc[]
+
+=== icon:bug[] Steps for debugging
+
+A high Kubernetes API server error rate can have multiple root causes.
+First check if you are generally able to connect the cluter's API through `kubectl`.
+If you can't, you most likely also received a `KubeApiServerFailure` and it probably makes sense to also look at its runbook even if you didn't.
+
+If you can still access the API server, look at the pods running in namespace `openshift-kube-apiserver`.
+Check if any of the API server pods seem to be crashing and ceck their logs.
+Also check etcd running in namespace `openshift-etcd` and see if any pods are crashing or logging errors.
+
+NOTE: If you have issues with viewing logs through `kubectl`, but the cluster generally still works, you might be able to look at the logs in elasticsearch.
+
+The API server logs can be fairly noisy, to help you narrow down the issue, you can connect to the Prometheus on the cluster and run the following query:
+
+[source,promql]
+----
+sum (rate(apiserver_request_total{code=~"(5..|429)"}[10m])) by (verb, resource, code)
+----
+
+This should return one or more time series.
+With these you should be able to narrow down the issue:
+
+* If all, or most, timeseries have the code `429` this most likely means the API server is overloaded.
+In that case, double-check if one or more master nodes have a high load.
+If so either investigate what generates the high load or increase master nodes size.
+
+* If you have a large amount of `504` errors, an upstream service is miss-behaving.
+Check etcd or the OpenShift API server in namespace `openshift-apiserver`.
+
+* If you see other codes than the generic `500`, check online what this error code means.
+
+* Check which verbs are effected.
+For example, if all writes fail, this might indicate a degraded etcd cluster.
+
+* Check what resources are effected.
+For example, if only OpenShift resources are effected, there is most likely an issue with the OpenShift API server and not the Kubernetes API server.
+
+This should give you a starting point to investigate the root cause.
+You should also check if there are other, related firing alerts.
+
+include::partial$runbooks/wip_note.adoc[]
+
+=== icon:wrench[] Tune
+
+If this alert isn't actionable, noisy, or was raised too late you may want to tune the SLO.
+
+You have the option tune the SLO through the component parameters.
+You can modify the objective, disable the page or ticket alert, or completely disable the SLO.
+
+The example below will set the SLO set the objective to 99.25% and disable the page alert.
+This means this SLO won't alert on-call anymore.
+
+[source,yaml]
+----
+slos:
+  kubernetes_api:
+    requests:
+      objective: 99.25
+      alerting:
+        page_alert:
+          enabled: false
+----
+
+include::partial$runbooks/objective_change_warning.adoc[]
+
+[[canary]]
+== API Uptime
+
+=== icon:glasses[] Overview
+
+This SLI measures the up-time of the Kubernetes API by probing the `/heathz` endpoint.
+If this SLI results in an alert, it means the Kubernetes API server is unable to handle requests or clients are simply unable to reach it.
+
+include::partial$runbooks/alert_types.adoc[]
+
+=== icon:bug[] Steps for debugging
+
+First try to access the Kubernetes API through `kubectl`.
+
+NOTE: If the API server is degraded, you might not be able to authenticate to OpenShift through the web console, but the API still might mostly work.
+Get the admin kubeconfig from the password manager and try to connect directly.
+
+If `kubectl` access still seems to work, try to check what error the probe is returning, by forwarding the blackbox exporter UI:
+
+[source,shell]
+----
+kubectl -n appuio-openshift4-slos port-forward svc/prometheus-blackbox-exporter 9115
+----
+
+You'll probably also want to follow the `KubeApiServerHighErrorRate` runbook.
+
+If you can't reach the Kubernetes API at all, fist check through the cloud provider portal if the master nodes are running.
+If they're running, but the Kubernetes API is still not reachable, try to connect to one of them using SSH.
+You'll need the SSH key stored in vault and use one of the LB VMs as a jumphost.
+
+[source,shell]
+----
+# For example: https://api.syn.vshn.net
+# IMPORTANT: do NOT add a trailing `/`. Commands below will fail.
+export COMMODORE_API_URL=<lieutenant-api-endpoint>
+
+# Set Project Syn cluster and tenant ID
+export CLUSTER_ID=<lieutenant-cluster-id> # Looks like: c-<something>
+export TENANT_ID=$(curl -sH "Authorization: Bearer $(commodore fetch-token)" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .tenant)
+
+# Login to vault
+export VAULT_ADDR=https://vault-prod.syn.vshn.net
+vault login -method=oidc
+
+# Fetch SSH key
+vault kv get -format=json clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cloudscale/ssh \
+  | jq -r '.data.data.private_key' | base64 --decode > ssh_key
+chmod 400 ssh_key
+
+# Connect to master node
+MASTER_NODE=etcd-0
+LB_HOST=$(grep -E "^Host.*${CLUSTER_ID}" ~/.ssh/sshop_config | head -1 | awk '{print $2}')
+ssh -J "${LB_HOST}" -i ssh_key "core@${MASTER_NODE}"
+----
+
+Check the logs in `/var/log/etcd`, `/var/log/kube-apiserver`, and `/var/log/containers`.
+Also see if any systemd service as crashed.
+
+
+include::partial$runbooks/wip_note.adoc[]
+
+=== icon:wrench[] Tune
+
+If this alert isn't actionable, noisy, or was raised too late you may want to tune the SLO.
+
+You have the option tune the SLO through the component parameters.
+You can modify the objective, disable the page or ticket alert, or completely disable the SLO.
+
+The example below will set the SLO set the objective to 99.25% and disable the page alert.
+This means this SLO won't alert on-call anymore.
+
+[source,yaml]
+----
+slos:
+  kubernetes_api:
+    canary:
+      objective: 99.9
+      _sli:
+        timeout: 10s
+        interval: 30s
+      alerting:
+        page_alert:
+          enabled: false
+
+----
+
+include::partial$runbooks/objective_change_warning.adoc[]
+
+[NOTE]
+====
+If you adjust the objective please be aware how this will impact alerting.
+
+With the default SLO of `99.9%` and probe interval of `10s`, if 6 probes fail in an hour we will emit a page alert.
+
+If you adjust the objective, this number will change and increasing the SLO or decreasing probe interval might result in unactionable alerts.
+You can calculate the number of failed probes latexmath:[f], given SLO latexmath:[slo] as percentage beteween 0 and 100 and the probe interval in seconds latexmath:[int].
+
+[latexmath]
+++++
+f = \dfrac{5164}{int} \left( 1-\dfrac{slo}{100} \right)
+++++
+
+====

--- a/docs/modules/ROOT/pages/runbooks/kubernetes_api.adoc
+++ b/docs/modules/ROOT/pages/runbooks/kubernetes_api.adoc
@@ -16,10 +16,10 @@ include::partial$runbooks/alert_types.adoc[]
 
 A high Kubernetes API server error rate can have multiple root causes.
 First check if you are generally able to connect the cluter's API through `kubectl`.
-If you can't, you most likely also received a `KubeApiServerFailure` and it probably makes sense to also look at its runbook even if you didn't.
+If you can't, you most likely also received a `KubeApiServerFailure` and it makes sense to also look at its runbook even if the alert didn't trigger.
 
 If you can still access the API server, look at the pods running in namespace `openshift-kube-apiserver`.
-Check if any of the API server pods seem to be crashing and ceck their logs.
+Check if any of the API server pods seem to be crashing and check their logs.
 Also check etcd running in namespace `openshift-etcd` and see if any pods are crashing or logging errors.
 
 NOTE: If you have issues with viewing logs through `kubectl`, but the cluster generally still works, you might be able to look at the logs in elasticsearch.
@@ -38,7 +38,7 @@ With these you should be able to narrow down the issue:
 In that case, double-check if one or more master nodes have a high load.
 If so either investigate what generates the high load or increase master nodes size.
 
-* If you have a large amount of `504` errors, an upstream service is miss-behaving.
+* If you have a large amount of `504` errors, an upstream service is misbehaving.
 Check etcd or the OpenShift API server in namespace `openshift-apiserver`.
 
 * If you see other codes than the generic `500`, check online what this error code means.
@@ -133,7 +133,7 @@ ssh -J "${LB_HOST}" -i ssh_key "core@${MASTER_NODE}"
 ----
 
 Check the logs in `/var/log/etcd`, `/var/log/kube-apiserver`, and `/var/log/containers`.
-Also see if any systemd service as crashed.
+Also see if any systemd service has crashed.
 
 
 include::partial$runbooks/wip_note.adoc[]

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -2,6 +2,7 @@
 * xref:references/parameters.adoc[Parameters]
 
 * SLO Runbooks
-** xref:runbooks/storage.adoc[Storage SLOs]
 ** xref:runbooks/ingress.adoc[Ingress SLOs]
+** xref:runbooks/kubernetes_api.adoc[Kubernetes API SLOs]
 ** xref:runbooks/workload-schedulability.adoc[Workload SLOs]
+** xref:runbooks/storage.adoc[Storage SLOs]

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/20_blackbox_exporter_configmap.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/20_blackbox_exporter_configmap.yaml
@@ -2,7 +2,10 @@ apiVersion: v1
 data:
   blackbox.yaml: "modules:\n  http_2xx:\n    http:\n      follow_redirects: true\n\
     \      preferred_ip_protocol: \"ip4\"\n    prober: \"http\"\n    timeout: \"5s\"\
-    \n  http_post_2xx:\n    http:\n      method: \"POST\"\n      preferred_ip_protocol:\
+    \n  http_kube_ca_2xx:\n    http:\n      follow_redirects: true\n      preferred_ip_protocol:\
+    \ \"ip4\"\n      prober: \"http\"\n      timeout: \"5s\"\n      tls_config:\n\
+    \        ca_file: \"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\"\n \
+    \ http_post_2xx:\n    http:\n      method: \"POST\"\n      preferred_ip_protocol:\
     \ \"ip4\"\n    prober: \"http\"\n  ssh_banner:\n    prober: \"tcp\"\n    tcp:\n\
     \      preferred_ip_protocol: \"ip4\"\n      query_response:\n        - expect:\
     \ \"^SSH-2.0-\"\n  tcp_connect:\n    prober: \"tcp\"\n    tcp:\n      preferred_ip_protocol:\

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/20_blackbox_exporter_deploy.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/20_blackbox_exporter_deploy.yaml
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f9549db9064c29961e29525a5096f645
+        checksum/config: a9adc40f8d8d85b4c56c9d7d160b483b
       labels:
         app.kubernetes.io/component: openshift4-slos
         app.kubernetes.io/instance: prometheus-blackbox-exporter

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/20_probes.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/20_probes.yaml
@@ -18,3 +18,24 @@ spec:
     staticConfig:
       static:
         - https://www.appuio.ch/
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  annotations: {}
+  labels:
+    name: kube-api-server
+  name: kube-api-server
+  namespace: appuio-openshift4-slos
+spec:
+  interval: 10s
+  jobName: probe-k8s-api
+  module: http_kube_ca_2xx
+  prober:
+    path: /probe
+    scheme: http
+    url: prometheus-blackbox-exporter.appuio-openshift4-slos.svc:9115
+  targets:
+    staticConfig:
+      static:
+        - https://kubernetes.default.svc.cluster.local/readyz

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/kubernetes_api.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/kubernetes_api.yaml
@@ -1,0 +1,395 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: kubernetes-api
+  name: kubernetes-api
+spec:
+  groups:
+    - name: sloth-slo-sli-recordings-kubernetes_api-canary
+      rules:
+        - expr: (1 - (sum_over_time(probe_success{job="probe-k8s-api"}[5m])/count_over_time(up{job="probe-k8s-api"}[5m])))
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+            sloth_window: 5m
+          record: slo:sli_error:ratio_rate5m
+        - expr: (1 - (sum_over_time(probe_success{job="probe-k8s-api"}[30m])/count_over_time(up{job="probe-k8s-api"}[30m])))
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+            sloth_window: 30m
+          record: slo:sli_error:ratio_rate30m
+        - expr: (1 - (sum_over_time(probe_success{job="probe-k8s-api"}[1h])/count_over_time(up{job="probe-k8s-api"}[1h])))
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+            sloth_window: 1h
+          record: slo:sli_error:ratio_rate1h
+        - expr: (1 - (sum_over_time(probe_success{job="probe-k8s-api"}[2h])/count_over_time(up{job="probe-k8s-api"}[2h])))
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+            sloth_window: 2h
+          record: slo:sli_error:ratio_rate2h
+        - expr: (1 - (sum_over_time(probe_success{job="probe-k8s-api"}[6h])/count_over_time(up{job="probe-k8s-api"}[6h])))
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+            sloth_window: 6h
+          record: slo:sli_error:ratio_rate6h
+        - expr: (1 - (sum_over_time(probe_success{job="probe-k8s-api"}[1d])/count_over_time(up{job="probe-k8s-api"}[1d])))
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+            sloth_window: 1d
+          record: slo:sli_error:ratio_rate1d
+        - expr: (1 - (sum_over_time(probe_success{job="probe-k8s-api"}[3d])/count_over_time(up{job="probe-k8s-api"}[3d])))
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+            sloth_window: 3d
+          record: slo:sli_error:ratio_rate3d
+        - expr: 'sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-canary",
+            sloth_service="kubernetes_api", sloth_slo="canary"}[30d])
+
+            / ignoring (sloth_window)
+
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-canary",
+            sloth_service="kubernetes_api", sloth_slo="canary"}[30d])
+
+            '
+          labels:
+            sloth_window: 30d
+          record: slo:sli_error:ratio_rate30d
+    - name: sloth-slo-meta-recordings-kubernetes_api-canary
+      rules:
+        - expr: vector(0.9990000000000001)
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+          record: slo:objective:ratio
+        - expr: vector(1-0.9990000000000001)
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+          record: slo:error_budget:ratio
+        - expr: vector(30)
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+          record: slo:time_period:days
+        - expr: 'slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api",
+            sloth_slo="canary"}
+
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+
+            slo:error_budget:ratio{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api",
+            sloth_slo="canary"}
+
+            '
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+          record: slo:current_burn_rate:ratio
+        - expr: 'slo:sli_error:ratio_rate30d{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api",
+            sloth_slo="canary"}
+
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+
+            slo:error_budget:ratio{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api",
+            sloth_slo="canary"}
+
+            '
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+          record: slo:period_burn_rate:ratio
+        - expr: 1 - slo:period_burn_rate:ratio{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api",
+            sloth_slo="canary"}
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+          record: slo:period_error_budget_remaining:ratio
+        - expr: vector(1)
+          labels:
+            sloth_id: kubernetes_api-canary
+            sloth_mode: cli-gen-prom
+            sloth_objective: '99.9'
+            sloth_service: kubernetes_api
+            sloth_slo: canary
+            sloth_spec: prometheus/v1
+            sloth_version: v0.10.0
+          record: sloth_slo_info
+    - name: sloth-slo-alerts-kubernetes_api-canary
+      rules:
+        - alert: KubeApiServeFailure
+          annotations:
+            runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/kubernetes_api.html#canary
+            summary: Probes to Kubernetes API server fail
+            title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: "(\n    (slo:sli_error:ratio_rate5m{sloth_id=\"kubernetes_api-canary\"\
+            , sloth_service=\"kubernetes_api\", sloth_slo=\"canary\"} > (14.4 * 0.0009999999999999432))\n\
+            \    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate1h{sloth_id=\"\
+            kubernetes_api-canary\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
+            canary\"} > (14.4 * 0.0009999999999999432))\n)\nor ignoring (sloth_window)\n\
+            (\n    (slo:sli_error:ratio_rate30m{sloth_id=\"kubernetes_api-canary\"\
+            , sloth_service=\"kubernetes_api\", sloth_slo=\"canary\"} > (6 * 0.0009999999999999432))\n\
+            \    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate6h{sloth_id=\"\
+            kubernetes_api-canary\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
+            canary\"} > (6 * 0.0009999999999999432))\n)\n"
+          labels:
+            severity: critical
+            sloth_severity: page
+            syn: 'true'
+            syn_component: openshift4-slos
+        - alert: KubeApiServeFailure
+          annotations:
+            runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/kubernetes_api.html#canary
+            summary: Probes to Kubernetes API server fail
+            title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: "(\n    (slo:sli_error:ratio_rate2h{sloth_id=\"kubernetes_api-canary\"\
+            , sloth_service=\"kubernetes_api\", sloth_slo=\"canary\"} > (3 * 0.0009999999999999432))\n\
+            \    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate1d{sloth_id=\"\
+            kubernetes_api-canary\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
+            canary\"} > (3 * 0.0009999999999999432))\n)\nor ignoring (sloth_window)\n\
+            (\n    (slo:sli_error:ratio_rate6h{sloth_id=\"kubernetes_api-canary\"\
+            , sloth_service=\"kubernetes_api\", sloth_slo=\"canary\"} > (1 * 0.0009999999999999432))\n\
+            \    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate3d{sloth_id=\"\
+            kubernetes_api-canary\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
+            canary\"} > (1 * 0.0009999999999999432))\n)\n"
+          labels:
+            severity: warning
+            sloth_severity: ticket
+            syn: 'true'
+            syn_component: openshift4-slos
+    - name: sloth-slo-sli-recordings-kubernetes_api-requests
+      rules:
+        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[5m])))
+
+            /
+
+            (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[5m])))
+
+            '
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+            sloth_window: 5m
+          record: slo:sli_error:ratio_rate5m
+        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[30m])))
+
+            /
+
+            (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[30m])))
+
+            '
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+            sloth_window: 30m
+          record: slo:sli_error:ratio_rate30m
+        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[1h])))
+
+            /
+
+            (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[1h])))
+
+            '
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+            sloth_window: 1h
+          record: slo:sli_error:ratio_rate1h
+        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[2h])))
+
+            /
+
+            (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[2h])))
+
+            '
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+            sloth_window: 2h
+          record: slo:sli_error:ratio_rate2h
+        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[6h])))
+
+            /
+
+            (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[6h])))
+
+            '
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+            sloth_window: 6h
+          record: slo:sli_error:ratio_rate6h
+        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[1d])))
+
+            /
+
+            (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[1d])))
+
+            '
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+            sloth_window: 1d
+          record: slo:sli_error:ratio_rate1d
+        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[3d])))
+
+            /
+
+            (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[3d])))
+
+            '
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+            sloth_window: 3d
+          record: slo:sli_error:ratio_rate3d
+        - expr: 'sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-requests",
+            sloth_service="kubernetes_api", sloth_slo="requests"}[30d])
+
+            / ignoring (sloth_window)
+
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-requests",
+            sloth_service="kubernetes_api", sloth_slo="requests"}[30d])
+
+            '
+          labels:
+            sloth_window: 30d
+          record: slo:sli_error:ratio_rate30d
+    - name: sloth-slo-meta-recordings-kubernetes_api-requests
+      rules:
+        - expr: vector(0.9990000000000001)
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+          record: slo:objective:ratio
+        - expr: vector(1-0.9990000000000001)
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+          record: slo:error_budget:ratio
+        - expr: vector(30)
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+          record: slo:time_period:days
+        - expr: 'slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api",
+            sloth_slo="requests"}
+
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+
+            slo:error_budget:ratio{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api",
+            sloth_slo="requests"}
+
+            '
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+          record: slo:current_burn_rate:ratio
+        - expr: 'slo:sli_error:ratio_rate30d{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api",
+            sloth_slo="requests"}
+
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+
+            slo:error_budget:ratio{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api",
+            sloth_slo="requests"}
+
+            '
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+          record: slo:period_burn_rate:ratio
+        - expr: 1 - slo:period_burn_rate:ratio{sloth_id="kubernetes_api-requests",
+            sloth_service="kubernetes_api", sloth_slo="requests"}
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+          record: slo:period_error_budget_remaining:ratio
+        - expr: vector(1)
+          labels:
+            sloth_id: kubernetes_api-requests
+            sloth_mode: cli-gen-prom
+            sloth_objective: '99.9'
+            sloth_service: kubernetes_api
+            sloth_slo: requests
+            sloth_spec: prometheus/v1
+            sloth_version: v0.10.0
+          record: sloth_slo_info
+    - name: sloth-slo-alerts-kubernetes_api-requests
+      rules:
+        - alert: KubeApiServerHighErrorRate
+          annotations:
+            runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/kubernetes_api.html#requests
+            summary: High Kubernetes API server error rate
+            title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: "(\n    (slo:sli_error:ratio_rate5m{sloth_id=\"kubernetes_api-requests\"\
+            , sloth_service=\"kubernetes_api\", sloth_slo=\"requests\"} > (14.4 *\
+            \ 0.0009999999999999432))\n    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate1h{sloth_id=\"\
+            kubernetes_api-requests\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
+            requests\"} > (14.4 * 0.0009999999999999432))\n)\nor ignoring (sloth_window)\n\
+            (\n    (slo:sli_error:ratio_rate30m{sloth_id=\"kubernetes_api-requests\"\
+            , sloth_service=\"kubernetes_api\", sloth_slo=\"requests\"} > (6 * 0.0009999999999999432))\n\
+            \    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate6h{sloth_id=\"\
+            kubernetes_api-requests\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
+            requests\"} > (6 * 0.0009999999999999432))\n)\n"
+          labels:
+            severity: critical
+            sloth_severity: page
+            syn: 'true'
+            syn_component: openshift4-slos
+        - alert: KubeApiServerHighErrorRate
+          annotations:
+            runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/kubernetes_api.html#requests
+            summary: High Kubernetes API server error rate
+            title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: "(\n    (slo:sli_error:ratio_rate2h{sloth_id=\"kubernetes_api-requests\"\
+            , sloth_service=\"kubernetes_api\", sloth_slo=\"requests\"} > (3 * 0.0009999999999999432))\n\
+            \    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate1d{sloth_id=\"\
+            kubernetes_api-requests\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
+            requests\"} > (3 * 0.0009999999999999432))\n)\nor ignoring (sloth_window)\n\
+            (\n    (slo:sli_error:ratio_rate6h{sloth_id=\"kubernetes_api-requests\"\
+            , sloth_service=\"kubernetes_api\", sloth_slo=\"requests\"} > (1 * 0.0009999999999999432))\n\
+            \    and ignoring (sloth_window)\n    (slo:sli_error:ratio_rate3d{sloth_id=\"\
+            kubernetes_api-requests\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
+            requests\"} > (1 * 0.0009999999999999432))\n)\n"
+          labels:
+            severity: warning
+            sloth_severity: ticket
+            syn: 'true'
+            syn_component: openshift4-slos

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/kubernetes_api.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/kubernetes_api.yaml
@@ -137,7 +137,7 @@ spec:
           record: sloth_slo_info
     - name: sloth-slo-alerts-kubernetes_api-canary
       rules:
-        - alert: KubeApiServeFailure
+        - alert: KubeApiServerFailure
           annotations:
             runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/kubernetes_api.html#canary
             summary: Probes to Kubernetes API server fail
@@ -158,7 +158,7 @@ spec:
             sloth_severity: page
             syn: 'true'
             syn_component: openshift4-slos
-        - alert: KubeApiServeFailure
+        - alert: KubeApiServerFailure
           annotations:
             runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/kubernetes_api.html#canary
             summary: Probes to Kubernetes API server fail


### PR DESCRIPTION

Adds two k8s API SLOs. One uptime SLO using probes and one using the reported error rate. Also adds runbooks, which definitely can be improved, but should give a starting point to debug

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
