### PR TITLE
Prefix all SLO alertnames and add an `slo: true` label

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -26,6 +26,7 @@ parameters:
       labels:
         syn: "true"
         syn_component: "openshift4-slos"
+        slo: "true"
       page_labels:
         severity: critical
       ticket_labels:

--- a/component/slos.libsonnet
+++ b/component/slos.libsonnet
@@ -23,7 +23,7 @@ local defaultSlos = {
             },
           },
           alerting: {
-            name: 'CanaryWorkloadTimesOut',
+            name: 'SLO_CanaryWorkloadTimesOut',
             annotations: {
               summary: 'Canary workloads time out.',
             },
@@ -50,7 +50,7 @@ local defaultSlos = {
             },
           },
           alerting: {
-            name: 'StorageOperationHighErrorRate',
+            name: 'SLO_StorageOperationHighErrorRate',
             annotations: {
               summary: 'High storage operation error rate',
             },
@@ -78,7 +78,7 @@ local defaultSlos = {
             },
           },
           alerting: {
-            name: 'ClusterIngressFailure',
+            name: 'SLO_ClusterIngressFailure',
             annotations: {
               summary: 'Probes to ingress canary fail',
               [if appsDomain != '' then 'canary_url']: 'canary-openshift-ingress-canary.%s' % appsDomain,
@@ -105,7 +105,7 @@ local defaultSlos = {
             },
           },
           alerting: {
-            name: 'KubeApiServerHighErrorRate',
+            name: 'SLO_KubeApiServerHighErrorRate',
             annotations: {
               summary: 'High Kubernetes API server error rate',
             },
@@ -121,7 +121,7 @@ local defaultSlos = {
             },
           },
           alerting: {
-            name: 'KubeApiServerFailure',
+            name: 'SLO_KubeApiServerFailure',
             annotations: {
               summary: 'Probes to Kubernetes API server fail',
             },

--- a/docs/modules/ROOT/pages/runbooks/kubernetes_api.adoc
+++ b/docs/modules/ROOT/pages/runbooks/kubernetes_api.adoc
@@ -16,7 +16,7 @@ include::partial$runbooks/alert_types.adoc[]
 
 A high Kubernetes API server error rate can have multiple root causes.
 First check if you are generally able to connect the cluter's API through `kubectl`.
-If you can't, you most likely also received a `KubeApiServerFailure` and it makes sense to also look at its runbook even if the alert didn't trigger.
+If you can't, you most likely also received a `SLO_KubeApiServerFailure` and it makes sense to also look at its runbook even if the alert didn't trigger.
 
 If you can still access the API server, look at the pods running in namespace `openshift-kube-apiserver`.
 Check if any of the API server pods seem to be crashing and check their logs.
@@ -101,7 +101,7 @@ If `kubectl` access still seems to work, try to check what error the probe is re
 kubectl -n appuio-openshift4-slos port-forward svc/prometheus-blackbox-exporter 9115
 ----
 
-You'll probably also want to follow the `KubeApiServerHighErrorRate` runbook.
+You'll probably also want to follow the `SLO_KubeApiServerHighErrorRate` runbook.
 
 If you can't reach the Kubernetes API at all, fist check through the cloud provider portal if the master nodes are running.
 If they're running, but the Kubernetes API is still not reachable, try to connect to one of them using SSH.

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/appuio-ch-http-get-availability.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/appuio-ch-http-get-availability.yaml
@@ -185,6 +185,7 @@ spec:
           labels:
             category: availability
             severity: warning
+            slo: 'true'
             sloth_severity: page
             syn: 'true'
             syn_component: openshift4-slos
@@ -209,6 +210,7 @@ spec:
             category: availability
             routing_key: myteam
             severity: warning
+            slo: 'true'
             sloth_severity: ticket
             syn: 'true'
             syn_component: openshift4-slos

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/ingress.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/ingress.yaml
@@ -137,7 +137,7 @@ spec:
           record: sloth_slo_info
     - name: sloth-slo-alerts-ingress-canary
       rules:
-        - alert: ClusterIngressFailure
+        - alert: SLO_ClusterIngressFailure
           annotations:
             canary_url: canary-openshift-ingress-canary.apps.foo.example.com
             runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/ingress.html#canary
@@ -155,10 +155,11 @@ spec:
             \ * 0.0025))\n)\n"
           labels:
             severity: critical
+            slo: 'true'
             sloth_severity: page
             syn: 'true'
             syn_component: openshift4-slos
-        - alert: ClusterIngressFailure
+        - alert: SLO_ClusterIngressFailure
           annotations:
             canary_url: canary-openshift-ingress-canary.apps.foo.example.com
             runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/ingress.html#canary
@@ -175,6 +176,7 @@ spec:
             ingress\", sloth_slo=\"canary\"} > (1 * 0.0025))\n)\n"
           labels:
             severity: warning
+            slo: 'true'
             sloth_severity: ticket
             syn: 'true'
             syn_component: openshift4-slos

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/kubernetes_api.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/kubernetes_api.yaml
@@ -137,7 +137,7 @@ spec:
           record: sloth_slo_info
     - name: sloth-slo-alerts-kubernetes_api-canary
       rules:
-        - alert: KubeApiServerFailure
+        - alert: SLO_KubeApiServerFailure
           annotations:
             runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/kubernetes_api.html#canary
             summary: Probes to Kubernetes API server fail
@@ -155,10 +155,11 @@ spec:
             canary\"} > (6 * 0.0009999999999999432))\n)\n"
           labels:
             severity: critical
+            slo: 'true'
             sloth_severity: page
             syn: 'true'
             syn_component: openshift4-slos
-        - alert: KubeApiServerFailure
+        - alert: SLO_KubeApiServerFailure
           annotations:
             runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/kubernetes_api.html#canary
             summary: Probes to Kubernetes API server fail
@@ -176,6 +177,7 @@ spec:
             canary\"} > (1 * 0.0009999999999999432))\n)\n"
           labels:
             severity: warning
+            slo: 'true'
             sloth_severity: ticket
             syn: 'true'
             syn_component: openshift4-slos
@@ -351,7 +353,7 @@ spec:
           record: sloth_slo_info
     - name: sloth-slo-alerts-kubernetes_api-requests
       rules:
-        - alert: KubeApiServerHighErrorRate
+        - alert: SLO_KubeApiServerHighErrorRate
           annotations:
             runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/kubernetes_api.html#requests
             summary: High Kubernetes API server error rate
@@ -369,10 +371,11 @@ spec:
             requests\"} > (6 * 0.0009999999999999432))\n)\n"
           labels:
             severity: critical
+            slo: 'true'
             sloth_severity: page
             syn: 'true'
             syn_component: openshift4-slos
-        - alert: KubeApiServerHighErrorRate
+        - alert: SLO_KubeApiServerHighErrorRate
           annotations:
             runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/kubernetes_api.html#requests
             summary: High Kubernetes API server error rate
@@ -390,6 +393,7 @@ spec:
             requests\"} > (1 * 0.0009999999999999432))\n)\n"
           labels:
             severity: warning
+            slo: 'true'
             sloth_severity: ticket
             syn: 'true'
             syn_component: openshift4-slos

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/storage.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/storage.yaml
@@ -179,7 +179,7 @@ spec:
           record: sloth_slo_info
     - name: sloth-slo-alerts-storage-csi-operations
       rules:
-        - alert: StorageOperationHighErrorRate
+        - alert: SLO_StorageOperationHighErrorRate
           annotations:
             runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/storage.html#csi-operations
             summary: High storage operation error rate
@@ -196,10 +196,11 @@ spec:
             } > (6 * 0.005))\n)\n"
           labels:
             severity: critical
+            slo: 'true'
             sloth_severity: page
             syn: 'true'
             syn_component: openshift4-slos
-        - alert: StorageOperationHighErrorRate
+        - alert: SLO_StorageOperationHighErrorRate
           annotations:
             runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/storage.html#csi-operations
             summary: High storage operation error rate
@@ -216,6 +217,7 @@ spec:
             } > (1 * 0.005))\n)\n"
           labels:
             severity: warning
+            slo: 'true'
             sloth_severity: ticket
             syn: 'true'
             syn_component: openshift4-slos

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/workload-schedulability.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/workload-schedulability.yaml
@@ -179,7 +179,7 @@ spec:
           record: sloth_slo_info
     - name: sloth-slo-alerts-workload-schedulability-canary
       rules:
-        - alert: CanaryWorkloadTimesOut
+        - alert: SLO_CanaryWorkloadTimesOut
           annotations:
             runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/workload-schedulability.html#canary
             summary: Canary workloads time out.
@@ -197,10 +197,11 @@ spec:
             , sloth_slo=\"canary\"} > (6 * 0.0025))\n)\n"
           labels:
             severity: critical
+            slo: 'true'
             sloth_severity: page
             syn: 'true'
             syn_component: openshift4-slos
-        - alert: CanaryWorkloadTimesOut
+        - alert: SLO_CanaryWorkloadTimesOut
           annotations:
             runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/workload-schedulability.html#canary
             summary: Canary workloads time out.
@@ -218,6 +219,7 @@ spec:
             , sloth_slo=\"canary\"} > (1 * 0.0025))\n)\n"
           labels:
             severity: warning
+            slo: 'true'
             sloth_severity: ticket
             syn: 'true'
             syn_component: openshift4-slos


### PR DESCRIPTION
This PR should make it easy to recognize SLO relevant AlertRules. We prefix all alerts with `SLO_` similarly to the `SYN_` prefix used for many existing alerts.

We also add a label `slo: 'true'` to every SLO alert, which makes filtering for them easier

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
