### PR TITLE
Improve Ingress SLO

### DIFF
--- a/component/slos.libsonnet
+++ b/component/slos.libsonnet
@@ -93,7 +93,7 @@ local defaultSlos = {
           description: 'OpenShift ingress SLO based on canary availability',
           sli: {
             raw: {
-              error_ratio_query: '1 - avg_over_time(ingress_canary_route_reachable[{{.window}}])',
+              error_ratio_query: '1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[{{.window}}])',
             },
           },
           alerting: {

--- a/component/slos.libsonnet
+++ b/component/slos.libsonnet
@@ -78,6 +78,13 @@ local defaultSlos = {
     local os = com.getValueOrDefault(inv.parameters, 'openshift', {}),
     local appsDomain = com.getValueOrDefault(os, 'appsDomain', ''),
 
+    extra_rules: [
+      {
+        record: 'appuio_ocp4_slo:ingress_canary_route_reachable:no_instance',
+        expr: 'max without(pod,instance) (ingress_canary_route_reachable)',
+      },
+    ],
+
     sloth_input: {
       version: 'prometheus/v1',
       service: 'ingress',

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/ingress.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/ingress.yaml
@@ -9,49 +9,49 @@ spec:
   groups:
     - name: sloth-slo-sli-recordings-ingress-canary
       rules:
-        - expr: (1 - avg_over_time(ingress_canary_route_reachable[5m]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[5m]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
             sloth_window: 5m
           record: slo:sli_error:ratio_rate5m
-        - expr: (1 - avg_over_time(ingress_canary_route_reachable[30m]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[30m]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
             sloth_window: 30m
           record: slo:sli_error:ratio_rate30m
-        - expr: (1 - avg_over_time(ingress_canary_route_reachable[1h]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[1h]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
             sloth_window: 1h
           record: slo:sli_error:ratio_rate1h
-        - expr: (1 - avg_over_time(ingress_canary_route_reachable[2h]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[2h]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
             sloth_window: 2h
           record: slo:sli_error:ratio_rate2h
-        - expr: (1 - avg_over_time(ingress_canary_route_reachable[6h]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[6h]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
             sloth_window: 6h
           record: slo:sli_error:ratio_rate6h
-        - expr: (1 - avg_over_time(ingress_canary_route_reachable[1d]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[1d]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
             sloth_window: 1d
           record: slo:sli_error:ratio_rate1d
-        - expr: (1 - avg_over_time(ingress_canary_route_reachable[3d]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[3d]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/ingress.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/ingress.yaml
@@ -184,3 +184,7 @@ spec:
             sloth_severity: ticket
             syn: 'true'
             syn_component: openshift4-slos
+    - name: syn-sloth-slo-ingress-extra-rules
+      rules:
+        - expr: max without(pod,instance) (ingress_canary_route_reachable)
+          record: appuio_ocp4_slo:ingress_canary_route_reachable:no_instance


### PR DESCRIPTION
Change the OpenShift cluster ingress SLI to use a cleaned version of the `ingress_canary_route_reachable` metric, with the `pod` and `instance` labels removed. We don't want those labels included, since they cause issues with the SLI and the SLO alerts when the ingress canary operator pod, which exposes the metric, is restarted.

We need #33 to create a new recording rule for `max without(pod,instance) (ingress_canary_route_reachable)`, since Prometheus doesn't support any of the following queries:

* `1 - avg_over_time((max without(pod,instance) (ingress_canary_route_reachable))[{{.window}}])` results in 
    ```
    Error executing query: invalid parameter "query": 1:79: parse error: ranges only allowed for vector selectors
    ```
* `1 - avg_over_time(max without(pod,instance) (ingress_canary_route_reachable[{{.window}}]))` results in
    ```
    Error executing query: invalid parameter "query": 1:46: parse error: expected type instant vector in aggregation expression, got range vector
    ```
* `1 - avg_over_time(ingress_canary_route_reachable[{{.window}}]) without (pod,instance)` results in
    ```
    Error executing query: invalid parameter "query": 1:55: parse error: unexpected <without>
    ```

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
