### PR TITLE
Add support for configuring extra Prometheus rules

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -17,9 +17,17 @@ local params = inv.parameters.openshift4_slos;
 local mergeSpec = function(name, spec)
   local slothRendered = std.parseJson(kap.yaml_load('%s/sloth-output/%s.yaml' % [ inv.parameters._base_directory, name ]));
   local metadata = com.makeMergeable(std.get(spec, 'metadata', {}));
+  local extra_rules = std.get(spec, 'extra_rules', []);
   kube._Object('monitoring.coreos.com/v1', 'PrometheusRule', kube.hyphenate(name)) {
     metadata+: metadata,
-    spec: slothRendered,
+    spec: slothRendered {
+      [if std.length(extra_rules) > 0 then 'groups']+: [
+        {
+          name: 'syn-sloth-slo-%s-extra-rules' % name,
+          rules: extra_rules,
+        },
+      ],
+    },
   }
 ;
 

--- a/component/slos.libsonnet
+++ b/component/slos.libsonnet
@@ -6,6 +6,18 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift4_slos;
 
+// Each entry in this object is used as the base definition for an SLI/SLO
+// pair managed by the component.
+// Field `sloth_input` is rendered into a valid input for Sloth and the
+// resulting Sloth output is loaded again in main.jsonnet and emitted as a
+// PrometheusRule object.
+// You can specify additional metadata for the resulting `PrometheusRule`
+// object in the optional top-level field `metadata`.
+// If you need additional Prometheus rules (e.g. a recording rule to remove
+// noisy labels from a metric) to define your SLI query, you can specify
+// complete additional rules in top-level field `extra_rules` in the
+// corresponding SLO's definition. The contents of this field are added to the
+// resulting PrometheusRule object as an extra rule group (cf. main.jsonnet).
 local defaultSlos = {
   'workload-schedulability': {
     local config = params.slos['workload-schedulability'],

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -6,6 +6,9 @@ parameters:
   openshift4_slos:
     specs:
       appuio-ch-http-get-availability:
+        extra_rules:
+          - record: appuio_ch_availability:probe_success:without_pod
+            expr: max without(pod) (probe_success{instance="https://www.appuio.ch/"})
         sloth_input:
           version: "prometheus/v1"
           service: "appuio-ch"
@@ -31,7 +34,7 @@ parameters:
                 raw:
                   error_ratio_query: |
                     1 - (
-                        sum_over_time(probe_success{instance="https://www.appuio.ch/"}[{{.window}}])
+                        sum_over_time(appuio_ch_availability:probe_success:without_pod[{{.window}}])
                       /
                         count_over_time(up{instance="https://www.appuio.ch/"}[{{.window}}])
                     )

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/appuio-ch-http-get-availability.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/appuio-ch-http-get-availability.yaml
@@ -9,9 +9,9 @@ spec:
   groups:
     - name: sloth-slo-sli-recordings-appuio-ch-appuio-ch-http-get-availability
       rules:
-        - expr: "(1 - (\n    sum_over_time(probe_success{instance=\"https://www.appuio.ch/\"\
-            }[5m])\n  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"\
-            }[5m])\n)\n)"
+        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[5m])\n\
+            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[5m])\n\
+            )\n)"
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -19,9 +19,9 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 5m
           record: slo:sli_error:ratio_rate5m
-        - expr: "(1 - (\n    sum_over_time(probe_success{instance=\"https://www.appuio.ch/\"\
-            }[30m])\n  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"\
-            }[30m])\n)\n)"
+        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[30m])\n\
+            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[30m])\n\
+            )\n)"
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -29,9 +29,9 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 30m
           record: slo:sli_error:ratio_rate30m
-        - expr: "(1 - (\n    sum_over_time(probe_success{instance=\"https://www.appuio.ch/\"\
-            }[1h])\n  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"\
-            }[1h])\n)\n)"
+        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[1h])\n\
+            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[1h])\n\
+            )\n)"
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -39,9 +39,9 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 1h
           record: slo:sli_error:ratio_rate1h
-        - expr: "(1 - (\n    sum_over_time(probe_success{instance=\"https://www.appuio.ch/\"\
-            }[2h])\n  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"\
-            }[2h])\n)\n)"
+        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[2h])\n\
+            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[2h])\n\
+            )\n)"
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -49,9 +49,9 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 2h
           record: slo:sli_error:ratio_rate2h
-        - expr: "(1 - (\n    sum_over_time(probe_success{instance=\"https://www.appuio.ch/\"\
-            }[6h])\n  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"\
-            }[6h])\n)\n)"
+        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[6h])\n\
+            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[6h])\n\
+            )\n)"
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -59,9 +59,9 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 6h
           record: slo:sli_error:ratio_rate6h
-        - expr: "(1 - (\n    sum_over_time(probe_success{instance=\"https://www.appuio.ch/\"\
-            }[1d])\n  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"\
-            }[1d])\n)\n)"
+        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[1d])\n\
+            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[1d])\n\
+            )\n)"
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -69,9 +69,9 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 1d
           record: slo:sli_error:ratio_rate1d
-        - expr: "(1 - (\n    sum_over_time(probe_success{instance=\"https://www.appuio.ch/\"\
-            }[3d])\n  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"\
-            }[3d])\n)\n)"
+        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[3d])\n\
+            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[3d])\n\
+            )\n)"
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -218,3 +218,7 @@ spec:
             sloth_severity: ticket
             syn: 'true'
             syn_component: openshift4-slos
+    - name: syn-sloth-slo-appuio-ch-http-get-availability-extra-rules
+      rules:
+        - expr: max without(pod) (probe_success{instance="https://www.appuio.ch/"})
+          record: appuio_ch_availability:probe_success:without_pod


### PR DESCRIPTION
We add support for configuring extra Prometheus rules through field `extra_rules` of each SLO spec defined in `slos.libsonnet`. We create an additional rule group in the resulting `PrometheusRule` object containing the extra rules, if any are specified. The extra group is named `syn-sloth-slo-<SLO name>-extra-rules`.

This can be useful to add additional custom recording rules, for example to drop some labels which change over time from a time series (e.g. pod name, or similar).

Factored out from #32 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
