### PR TITLE
Fix misspelled parameter name in documentation

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -380,16 +380,16 @@ It must be a valid Kubernetes name.
 [INFO]
 The `.spec.prober` part is automatically filled from the Blackbox exporter configuration and can omitted.
 
-== `scheduler_canary_controller`
+== `canary_scheduler_controller`
 
 [horizontal]
 type:: dictionary
 
-`scheduler_canary_controller` allows setting up the canary controller to test workload schedulability.
+`canary_scheduler_controller` allows setting up the canary controller to test workload schedulability.
 The manifests are rendered using Kustomize.
 
 
-=== `scheduler_canary_controller.enabled`
+=== `canary_scheduler_controller.enabled`
 
 [horizontal]
 type:: boolean
@@ -398,7 +398,7 @@ default:: `true`
 Controls whether the controller is deployed.
 
 
-=== `scheduler_canary_controller.manifests_version`
+=== `canary_scheduler_controller.manifests_version`
 
 [horizontal]
 type:: string
@@ -408,7 +408,7 @@ The Git reference to the canary controller manifests.
 The default is the tag of the canary controller image.
 
 
-=== `scheduler_canary_controller.kustomize_input`
+=== `canary_scheduler_controller.kustomize_input`
 
 [horizontal]
 type:: dictionary

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/20_blackbox_exporter_configmap.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/20_blackbox_exporter_configmap.yaml
@@ -1,14 +1,36 @@
 apiVersion: v1
 data:
-  blackbox.yaml: "modules:\n  http_2xx:\n    http:\n      follow_redirects: true\n\
-    \      preferred_ip_protocol: \"ip4\"\n    prober: \"http\"\n    timeout: \"5s\"\
-    \n  http_kube_ca_2xx:\n    http:\n      follow_redirects: true\n      preferred_ip_protocol:\
-    \ \"ip4\"\n      tls_config:\n        ca_file: \"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\"\
-    \n    prober: \"http\"\n    timeout: \"5s\"\n  http_post_2xx:\n    http:\n   \
-    \   method: \"POST\"\n      preferred_ip_protocol: \"ip4\"\n    prober: \"http\"\
-    \n  ssh_banner:\n    prober: \"tcp\"\n    tcp:\n      preferred_ip_protocol: \"\
-    ip4\"\n      query_response:\n        - expect: \"^SSH-2.0-\"\n  tcp_connect:\n\
-    \    prober: \"tcp\"\n    tcp:\n      preferred_ip_protocol: \"ip4\""
+  blackbox.yaml: |-
+    modules:
+      http_2xx:
+        http:
+          follow_redirects: true
+          preferred_ip_protocol: "ip4"
+        prober: "http"
+        timeout: "5s"
+      http_kube_ca_2xx:
+        http:
+          follow_redirects: true
+          preferred_ip_protocol: "ip4"
+          tls_config:
+            ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        prober: "http"
+        timeout: "5s"
+      http_post_2xx:
+        http:
+          method: "POST"
+          preferred_ip_protocol: "ip4"
+        prober: "http"
+      ssh_banner:
+        prober: "tcp"
+        tcp:
+          preferred_ip_protocol: "ip4"
+          query_response:
+            - expect: "^SSH-2.0-"
+      tcp_connect:
+        prober: "tcp"
+        tcp:
+          preferred_ip_protocol: "ip4"
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/appuio-ch-http-get-availability.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/appuio-ch-http-get-availability.yaml
@@ -9,9 +9,13 @@ spec:
   groups:
     - name: sloth-slo-sli-recordings-appuio-ch-appuio-ch-http-get-availability
       rules:
-        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[5m])\n\
-            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[5m])\n\
-            )\n)"
+        - expr: |-
+            (1 - (
+                sum_over_time(appuio_ch_availability:probe_success:without_pod[5m])
+              /
+                count_over_time(up{instance="https://www.appuio.ch/"}[5m])
+            )
+            )
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -19,9 +23,13 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 5m
           record: slo:sli_error:ratio_rate5m
-        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[30m])\n\
-            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[30m])\n\
-            )\n)"
+        - expr: |-
+            (1 - (
+                sum_over_time(appuio_ch_availability:probe_success:without_pod[30m])
+              /
+                count_over_time(up{instance="https://www.appuio.ch/"}[30m])
+            )
+            )
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -29,9 +37,13 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 30m
           record: slo:sli_error:ratio_rate30m
-        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[1h])\n\
-            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[1h])\n\
-            )\n)"
+        - expr: |-
+            (1 - (
+                sum_over_time(appuio_ch_availability:probe_success:without_pod[1h])
+              /
+                count_over_time(up{instance="https://www.appuio.ch/"}[1h])
+            )
+            )
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -39,9 +51,13 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 1h
           record: slo:sli_error:ratio_rate1h
-        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[2h])\n\
-            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[2h])\n\
-            )\n)"
+        - expr: |-
+            (1 - (
+                sum_over_time(appuio_ch_availability:probe_success:without_pod[2h])
+              /
+                count_over_time(up{instance="https://www.appuio.ch/"}[2h])
+            )
+            )
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -49,9 +65,13 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 2h
           record: slo:sli_error:ratio_rate2h
-        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[6h])\n\
-            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[6h])\n\
-            )\n)"
+        - expr: |-
+            (1 - (
+                sum_over_time(appuio_ch_availability:probe_success:without_pod[6h])
+              /
+                count_over_time(up{instance="https://www.appuio.ch/"}[6h])
+            )
+            )
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -59,9 +79,13 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 6h
           record: slo:sli_error:ratio_rate6h
-        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[1d])\n\
-            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[1d])\n\
-            )\n)"
+        - expr: |-
+            (1 - (
+                sum_over_time(appuio_ch_availability:probe_success:without_pod[1d])
+              /
+                count_over_time(up{instance="https://www.appuio.ch/"}[1d])
+            )
+            )
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -69,9 +93,13 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 1d
           record: slo:sli_error:ratio_rate1d
-        - expr: "(1 - (\n    sum_over_time(appuio_ch_availability:probe_success:without_pod[3d])\n\
-            \  /\n    count_over_time(up{instance=\"https://www.appuio.ch/\"}[3d])\n\
-            )\n)"
+        - expr: |-
+            (1 - (
+                sum_over_time(appuio_ch_availability:probe_success:without_pod[3d])
+              /
+                count_over_time(up{instance="https://www.appuio.ch/"}[3d])
+            )
+            )
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -79,15 +107,10 @@ spec:
             sloth_slo: appuio-ch-http-get-availability
             sloth_window: 3d
           record: slo:sli_error:ratio_rate3d
-        - expr: 'sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="appuio-ch-appuio-ch-http-get-availability",
-            sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"}[30d])
-
+        - expr: |
+            sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"}[30d])
             / ignoring (sloth_window)
-
-            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="appuio-ch-appuio-ch-http-get-availability",
-            sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"}[30d])
-
-            '
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"}[30d])
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -118,30 +141,20 @@ spec:
             sloth_service: appuio-ch
             sloth_slo: appuio-ch-http-get-availability
           record: slo:time_period:days
-        - expr: 'slo:sli_error:ratio_rate5m{sloth_id="appuio-ch-appuio-ch-http-get-availability",
-            sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"}
-
+        - expr: |
+            slo:sli_error:ratio_rate5m{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="appuio-ch-appuio-ch-http-get-availability",
-            sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"}
-
-            '
+            slo:error_budget:ratio{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"}
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
             sloth_service: appuio-ch
             sloth_slo: appuio-ch-http-get-availability
           record: slo:current_burn_rate:ratio
-        - expr: 'slo:sli_error:ratio_rate30d{sloth_id="appuio-ch-appuio-ch-http-get-availability",
-            sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"}
-
+        - expr: |
+            slo:sli_error:ratio_rate30d{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="appuio-ch-appuio-ch-http-get-availability",
-            sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"}
-
-            '
+            slo:error_budget:ratio{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"}
           labels:
             owner: myteam
             sloth_id: appuio-ch-appuio-ch-http-get-availability
@@ -174,18 +187,18 @@ spec:
             summary: High error rate on 'appuio.ch' responses
             title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate5m{sloth_id=\"appuio-ch-appuio-ch-http-get-availability\"\
-            , sloth_service=\"appuio-ch\", sloth_slo=\"appuio-ch-http-get-availability\"\
-            } > (14.4 * 0.0009999999999999432)) without (sloth_window)\n    and\n\
-            \    max(slo:sli_error:ratio_rate1h{sloth_id=\"appuio-ch-appuio-ch-http-get-availability\"\
-            , sloth_service=\"appuio-ch\", sloth_slo=\"appuio-ch-http-get-availability\"\
-            } > (14.4 * 0.0009999999999999432)) without (sloth_window)\n)\nor\n(\n\
-            \    max(slo:sli_error:ratio_rate30m{sloth_id=\"appuio-ch-appuio-ch-http-get-availability\"\
-            , sloth_service=\"appuio-ch\", sloth_slo=\"appuio-ch-http-get-availability\"\
-            } > (6 * 0.0009999999999999432)) without (sloth_window)\n    and\n   \
-            \ max(slo:sli_error:ratio_rate6h{sloth_id=\"appuio-ch-appuio-ch-http-get-availability\"\
-            , sloth_service=\"appuio-ch\", sloth_slo=\"appuio-ch-http-get-availability\"\
-            } > (6 * 0.0009999999999999432)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate5m{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1h{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate30m{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"} > (6 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate6h{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"} > (6 * 0.0009999999999999432)) without (sloth_window)
+            )
           labels:
             category: availability
             severity: warning
@@ -198,18 +211,18 @@ spec:
             summary: High error rate on 'appuio.ch' responses
             title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate2h{sloth_id=\"appuio-ch-appuio-ch-http-get-availability\"\
-            , sloth_service=\"appuio-ch\", sloth_slo=\"appuio-ch-http-get-availability\"\
-            } > (3 * 0.0009999999999999432)) without (sloth_window)\n    and\n   \
-            \ max(slo:sli_error:ratio_rate1d{sloth_id=\"appuio-ch-appuio-ch-http-get-availability\"\
-            , sloth_service=\"appuio-ch\", sloth_slo=\"appuio-ch-http-get-availability\"\
-            } > (3 * 0.0009999999999999432)) without (sloth_window)\n)\nor\n(\n  \
-            \  max(slo:sli_error:ratio_rate6h{sloth_id=\"appuio-ch-appuio-ch-http-get-availability\"\
-            , sloth_service=\"appuio-ch\", sloth_slo=\"appuio-ch-http-get-availability\"\
-            } > (1 * 0.0009999999999999432)) without (sloth_window)\n    and\n   \
-            \ max(slo:sli_error:ratio_rate3d{sloth_id=\"appuio-ch-appuio-ch-http-get-availability\"\
-            , sloth_service=\"appuio-ch\", sloth_slo=\"appuio-ch-http-get-availability\"\
-            } > (1 * 0.0009999999999999432)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate2h{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"} > (3 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1d{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"} > (3 * 0.0009999999999999432)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate6h{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"} > (1 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate3d{sloth_id="appuio-ch-appuio-ch-http-get-availability", sloth_service="appuio-ch", sloth_slo="appuio-ch-http-get-availability"} > (1 * 0.0009999999999999432)) without (sloth_window)
+            )
           labels:
             category: availability
             routing_key: myteam

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/ingress.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/ingress.yaml
@@ -58,15 +58,10 @@ spec:
             sloth_slo: canary
             sloth_window: 3d
           record: slo:sli_error:ratio_rate3d
-        - expr: 'sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="ingress-canary",
-            sloth_service="ingress", sloth_slo="canary"}[30d])
-
+        - expr: |
+            sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"}[30d])
             / ignoring (sloth_window)
-
-            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="ingress-canary",
-            sloth_service="ingress", sloth_slo="canary"}[30d])
-
-            '
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"}[30d])
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
@@ -93,29 +88,19 @@ spec:
             sloth_service: ingress
             sloth_slo: canary
           record: slo:time_period:days
-        - expr: 'slo:sli_error:ratio_rate5m{sloth_id="ingress-canary", sloth_service="ingress",
-            sloth_slo="canary"}
-
+        - expr: |
+            slo:sli_error:ratio_rate5m{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="ingress-canary", sloth_service="ingress",
-            sloth_slo="canary"}
-
-            '
+            slo:error_budget:ratio{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"}
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
           record: slo:current_burn_rate:ratio
-        - expr: 'slo:sli_error:ratio_rate30d{sloth_id="ingress-canary", sloth_service="ingress",
-            sloth_slo="canary"}
-
+        - expr: |
+            slo:sli_error:ratio_rate30d{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="ingress-canary", sloth_service="ingress",
-            sloth_slo="canary"}
-
-            '
+            slo:error_budget:ratio{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"}
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
@@ -147,15 +132,18 @@ spec:
             summary: Probes to ingress canary fail
             title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate5m{sloth_id=\"ingress-canary\"\
-            , sloth_service=\"ingress\", sloth_slo=\"canary\"} > (14.4 * 0.0025))\
-            \ without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate1h{sloth_id=\"\
-            ingress-canary\", sloth_service=\"ingress\", sloth_slo=\"canary\"} > (14.4\
-            \ * 0.0025)) without (sloth_window)\n)\nor\n(\n    max(slo:sli_error:ratio_rate30m{sloth_id=\"\
-            ingress-canary\", sloth_service=\"ingress\", sloth_slo=\"canary\"} > (6\
-            \ * 0.0025)) without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate6h{sloth_id=\"\
-            ingress-canary\", sloth_service=\"ingress\", sloth_slo=\"canary\"} > (6\
-            \ * 0.0025)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate5m{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"} > (14.4 * 0.0025)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1h{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"} > (14.4 * 0.0025)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate30m{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"} > (6 * 0.0025)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate6h{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"} > (6 * 0.0025)) without (sloth_window)
+            )
           labels:
             severity: critical
             slo: 'true'
@@ -169,15 +157,18 @@ spec:
             summary: Probes to ingress canary fail
             title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate2h{sloth_id=\"ingress-canary\"\
-            , sloth_service=\"ingress\", sloth_slo=\"canary\"} > (3 * 0.0025)) without\
-            \ (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate1d{sloth_id=\"\
-            ingress-canary\", sloth_service=\"ingress\", sloth_slo=\"canary\"} > (3\
-            \ * 0.0025)) without (sloth_window)\n)\nor\n(\n    max(slo:sli_error:ratio_rate6h{sloth_id=\"\
-            ingress-canary\", sloth_service=\"ingress\", sloth_slo=\"canary\"} > (1\
-            \ * 0.0025)) without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate3d{sloth_id=\"\
-            ingress-canary\", sloth_service=\"ingress\", sloth_slo=\"canary\"} > (1\
-            \ * 0.0025)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate2h{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"} > (3 * 0.0025)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1d{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"} > (3 * 0.0025)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate6h{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"} > (1 * 0.0025)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate3d{sloth_id="ingress-canary", sloth_service="ingress", sloth_slo="canary"} > (1 * 0.0025)) without (sloth_window)
+            )
           labels:
             severity: warning
             slo: 'true'

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/kubernetes_api.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/kubernetes_api.yaml
@@ -58,15 +58,10 @@ spec:
             sloth_slo: canary
             sloth_window: 3d
           record: slo:sli_error:ratio_rate3d
-        - expr: 'sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-canary",
-            sloth_service="kubernetes_api", sloth_slo="canary"}[30d])
-
+        - expr: |
+            sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"}[30d])
             / ignoring (sloth_window)
-
-            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-canary",
-            sloth_service="kubernetes_api", sloth_slo="canary"}[30d])
-
-            '
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"}[30d])
           labels:
             sloth_id: kubernetes_api-canary
             sloth_service: kubernetes_api
@@ -93,29 +88,19 @@ spec:
             sloth_service: kubernetes_api
             sloth_slo: canary
           record: slo:time_period:days
-        - expr: 'slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api",
-            sloth_slo="canary"}
-
+        - expr: |
+            slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api",
-            sloth_slo="canary"}
-
-            '
+            slo:error_budget:ratio{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"}
           labels:
             sloth_id: kubernetes_api-canary
             sloth_service: kubernetes_api
             sloth_slo: canary
           record: slo:current_burn_rate:ratio
-        - expr: 'slo:sli_error:ratio_rate30d{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api",
-            sloth_slo="canary"}
-
+        - expr: |
+            slo:sli_error:ratio_rate30d{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api",
-            sloth_slo="canary"}
-
-            '
+            slo:error_budget:ratio{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"}
           labels:
             sloth_id: kubernetes_api-canary
             sloth_service: kubernetes_api
@@ -146,16 +131,18 @@ spec:
             summary: Probes to Kubernetes API server fail
             title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate5m{sloth_id=\"kubernetes_api-canary\"\
-            , sloth_service=\"kubernetes_api\", sloth_slo=\"canary\"} > (14.4 * 0.0009999999999999432))\
-            \ without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate1h{sloth_id=\"\
-            kubernetes_api-canary\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
-            canary\"} > (14.4 * 0.0009999999999999432)) without (sloth_window)\n)\n\
-            or\n(\n    max(slo:sli_error:ratio_rate30m{sloth_id=\"kubernetes_api-canary\"\
-            , sloth_service=\"kubernetes_api\", sloth_slo=\"canary\"} > (6 * 0.0009999999999999432))\
-            \ without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate6h{sloth_id=\"\
-            kubernetes_api-canary\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
-            canary\"} > (6 * 0.0009999999999999432)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1h{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate30m{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"} > (6 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate6h{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"} > (6 * 0.0009999999999999432)) without (sloth_window)
+            )
           labels:
             severity: critical
             slo: 'true'
@@ -168,16 +155,18 @@ spec:
             summary: Probes to Kubernetes API server fail
             title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate2h{sloth_id=\"kubernetes_api-canary\"\
-            , sloth_service=\"kubernetes_api\", sloth_slo=\"canary\"} > (3 * 0.0009999999999999432))\
-            \ without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate1d{sloth_id=\"\
-            kubernetes_api-canary\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
-            canary\"} > (3 * 0.0009999999999999432)) without (sloth_window)\n)\nor\n\
-            (\n    max(slo:sli_error:ratio_rate6h{sloth_id=\"kubernetes_api-canary\"\
-            , sloth_service=\"kubernetes_api\", sloth_slo=\"canary\"} > (1 * 0.0009999999999999432))\
-            \ without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate3d{sloth_id=\"\
-            kubernetes_api-canary\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
-            canary\"} > (1 * 0.0009999999999999432)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate2h{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"} > (3 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1d{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"} > (3 * 0.0009999999999999432)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate6h{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"} > (1 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate3d{sloth_id="kubernetes_api-canary", sloth_service="kubernetes_api", sloth_slo="canary"} > (1 * 0.0009999999999999432)) without (sloth_window)
+            )
           labels:
             severity: warning
             slo: 'true'
@@ -186,106 +175,80 @@ spec:
             syn_component: openshift4-slos
     - name: sloth-slo-sli-recordings-kubernetes_api-requests
       rules:
-        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[5m])))
-
+        - expr: |
+            (sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[5m])))
             /
-
             (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[5m])))
-
-            '
           labels:
             sloth_id: kubernetes_api-requests
             sloth_service: kubernetes_api
             sloth_slo: requests
             sloth_window: 5m
           record: slo:sli_error:ratio_rate5m
-        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[30m])))
-
+        - expr: |
+            (sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[30m])))
             /
-
             (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[30m])))
-
-            '
           labels:
             sloth_id: kubernetes_api-requests
             sloth_service: kubernetes_api
             sloth_slo: requests
             sloth_window: 30m
           record: slo:sli_error:ratio_rate30m
-        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[1h])))
-
+        - expr: |
+            (sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[1h])))
             /
-
             (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[1h])))
-
-            '
           labels:
             sloth_id: kubernetes_api-requests
             sloth_service: kubernetes_api
             sloth_slo: requests
             sloth_window: 1h
           record: slo:sli_error:ratio_rate1h
-        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[2h])))
-
+        - expr: |
+            (sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[2h])))
             /
-
             (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[2h])))
-
-            '
           labels:
             sloth_id: kubernetes_api-requests
             sloth_service: kubernetes_api
             sloth_slo: requests
             sloth_window: 2h
           record: slo:sli_error:ratio_rate2h
-        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[6h])))
-
+        - expr: |
+            (sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[6h])))
             /
-
             (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[6h])))
-
-            '
           labels:
             sloth_id: kubernetes_api-requests
             sloth_service: kubernetes_api
             sloth_slo: requests
             sloth_window: 6h
           record: slo:sli_error:ratio_rate6h
-        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[1d])))
-
+        - expr: |
+            (sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[1d])))
             /
-
             (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[1d])))
-
-            '
           labels:
             sloth_id: kubernetes_api-requests
             sloth_service: kubernetes_api
             sloth_slo: requests
             sloth_window: 1d
           record: slo:sli_error:ratio_rate1d
-        - expr: '(sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[3d])))
-
+        - expr: |
+            (sum(rate(apiserver_request_total{code=~"(5..|429)",apiserver=~"kube-apiserver"}[3d])))
             /
-
             (sum(rate(apiserver_request_total{apiserver=~"kube-apiserver"}[3d])))
-
-            '
           labels:
             sloth_id: kubernetes_api-requests
             sloth_service: kubernetes_api
             sloth_slo: requests
             sloth_window: 3d
           record: slo:sli_error:ratio_rate3d
-        - expr: 'sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-requests",
-            sloth_service="kubernetes_api", sloth_slo="requests"}[30d])
-
+        - expr: |
+            sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"}[30d])
             / ignoring (sloth_window)
-
-            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-requests",
-            sloth_service="kubernetes_api", sloth_slo="requests"}[30d])
-
-            '
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"}[30d])
           labels:
             sloth_id: kubernetes_api-requests
             sloth_service: kubernetes_api
@@ -312,29 +275,19 @@ spec:
             sloth_service: kubernetes_api
             sloth_slo: requests
           record: slo:time_period:days
-        - expr: 'slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api",
-            sloth_slo="requests"}
-
+        - expr: |
+            slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api",
-            sloth_slo="requests"}
-
-            '
+            slo:error_budget:ratio{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"}
           labels:
             sloth_id: kubernetes_api-requests
             sloth_service: kubernetes_api
             sloth_slo: requests
           record: slo:current_burn_rate:ratio
-        - expr: 'slo:sli_error:ratio_rate30d{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api",
-            sloth_slo="requests"}
-
+        - expr: |
+            slo:sli_error:ratio_rate30d{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api",
-            sloth_slo="requests"}
-
-            '
+            slo:error_budget:ratio{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"}
           labels:
             sloth_id: kubernetes_api-requests
             sloth_service: kubernetes_api
@@ -365,16 +318,18 @@ spec:
             summary: High Kubernetes API server error rate
             title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate5m{sloth_id=\"kubernetes_api-requests\"\
-            , sloth_service=\"kubernetes_api\", sloth_slo=\"requests\"} > (14.4 *\
-            \ 0.0009999999999999432)) without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate1h{sloth_id=\"\
-            kubernetes_api-requests\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
-            requests\"} > (14.4 * 0.0009999999999999432)) without (sloth_window)\n\
-            )\nor\n(\n    max(slo:sli_error:ratio_rate30m{sloth_id=\"kubernetes_api-requests\"\
-            , sloth_service=\"kubernetes_api\", sloth_slo=\"requests\"} > (6 * 0.0009999999999999432))\
-            \ without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate6h{sloth_id=\"\
-            kubernetes_api-requests\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
-            requests\"} > (6 * 0.0009999999999999432)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate5m{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1h{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate30m{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"} > (6 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate6h{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"} > (6 * 0.0009999999999999432)) without (sloth_window)
+            )
           labels:
             severity: critical
             slo: 'true'
@@ -387,16 +342,18 @@ spec:
             summary: High Kubernetes API server error rate
             title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate2h{sloth_id=\"kubernetes_api-requests\"\
-            , sloth_service=\"kubernetes_api\", sloth_slo=\"requests\"} > (3 * 0.0009999999999999432))\
-            \ without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate1d{sloth_id=\"\
-            kubernetes_api-requests\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
-            requests\"} > (3 * 0.0009999999999999432)) without (sloth_window)\n)\n\
-            or\n(\n    max(slo:sli_error:ratio_rate6h{sloth_id=\"kubernetes_api-requests\"\
-            , sloth_service=\"kubernetes_api\", sloth_slo=\"requests\"} > (1 * 0.0009999999999999432))\
-            \ without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate3d{sloth_id=\"\
-            kubernetes_api-requests\", sloth_service=\"kubernetes_api\", sloth_slo=\"\
-            requests\"} > (1 * 0.0009999999999999432)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate2h{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"} > (3 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1d{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"} > (3 * 0.0009999999999999432)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate6h{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"} > (1 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate3d{sloth_id="kubernetes_api-requests", sloth_service="kubernetes_api", sloth_slo="requests"} > (1 * 0.0009999999999999432)) without (sloth_window)
+            )
           labels:
             severity: warning
             slo: 'true'

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/network.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/network.yaml
@@ -9,106 +9,80 @@ spec:
   groups:
     - name: sloth-slo-sli-recordings-network-requests
       rules:
-        - expr: '(sum(rate(ping_rtt_seconds_count{reason="lost"}[5m])))
-
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[5m])))
             /
-
             (sum(rate(ping_rtt_seconds_count[5m])))
-
-            '
           labels:
             sloth_id: network-requests
             sloth_service: network
             sloth_slo: requests
             sloth_window: 5m
           record: slo:sli_error:ratio_rate5m
-        - expr: '(sum(rate(ping_rtt_seconds_count{reason="lost"}[30m])))
-
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[30m])))
             /
-
             (sum(rate(ping_rtt_seconds_count[30m])))
-
-            '
           labels:
             sloth_id: network-requests
             sloth_service: network
             sloth_slo: requests
             sloth_window: 30m
           record: slo:sli_error:ratio_rate30m
-        - expr: '(sum(rate(ping_rtt_seconds_count{reason="lost"}[1h])))
-
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[1h])))
             /
-
             (sum(rate(ping_rtt_seconds_count[1h])))
-
-            '
           labels:
             sloth_id: network-requests
             sloth_service: network
             sloth_slo: requests
             sloth_window: 1h
           record: slo:sli_error:ratio_rate1h
-        - expr: '(sum(rate(ping_rtt_seconds_count{reason="lost"}[2h])))
-
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[2h])))
             /
-
             (sum(rate(ping_rtt_seconds_count[2h])))
-
-            '
           labels:
             sloth_id: network-requests
             sloth_service: network
             sloth_slo: requests
             sloth_window: 2h
           record: slo:sli_error:ratio_rate2h
-        - expr: '(sum(rate(ping_rtt_seconds_count{reason="lost"}[6h])))
-
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[6h])))
             /
-
             (sum(rate(ping_rtt_seconds_count[6h])))
-
-            '
           labels:
             sloth_id: network-requests
             sloth_service: network
             sloth_slo: requests
             sloth_window: 6h
           record: slo:sli_error:ratio_rate6h
-        - expr: '(sum(rate(ping_rtt_seconds_count{reason="lost"}[1d])))
-
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[1d])))
             /
-
             (sum(rate(ping_rtt_seconds_count[1d])))
-
-            '
           labels:
             sloth_id: network-requests
             sloth_service: network
             sloth_slo: requests
             sloth_window: 1d
           record: slo:sli_error:ratio_rate1d
-        - expr: '(sum(rate(ping_rtt_seconds_count{reason="lost"}[3d])))
-
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[3d])))
             /
-
             (sum(rate(ping_rtt_seconds_count[3d])))
-
-            '
           labels:
             sloth_id: network-requests
             sloth_service: network
             sloth_slo: requests
             sloth_window: 3d
           record: slo:sli_error:ratio_rate3d
-        - expr: 'sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="network-requests",
-            sloth_service="network", sloth_slo="requests"}[30d])
-
+        - expr: |
+            sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"}[30d])
             / ignoring (sloth_window)
-
-            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="network-requests",
-            sloth_service="network", sloth_slo="requests"}[30d])
-
-            '
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"}[30d])
           labels:
             sloth_id: network-requests
             sloth_service: network
@@ -135,29 +109,19 @@ spec:
             sloth_service: network
             sloth_slo: requests
           record: slo:time_period:days
-        - expr: 'slo:sli_error:ratio_rate5m{sloth_id="network-requests", sloth_service="network",
-            sloth_slo="requests"}
-
+        - expr: |
+            slo:sli_error:ratio_rate5m{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="network-requests", sloth_service="network",
-            sloth_slo="requests"}
-
-            '
+            slo:error_budget:ratio{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"}
           labels:
             sloth_id: network-requests
             sloth_service: network
             sloth_slo: requests
           record: slo:current_burn_rate:ratio
-        - expr: 'slo:sli_error:ratio_rate30d{sloth_id="network-requests", sloth_service="network",
-            sloth_slo="requests"}
-
+        - expr: |
+            slo:sli_error:ratio_rate30d{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="network-requests", sloth_service="network",
-            sloth_slo="requests"}
-
-            '
+            slo:error_budget:ratio{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"}
           labels:
             sloth_id: network-requests
             sloth_service: network
@@ -188,15 +152,18 @@ spec:
             summary: High number of lost network packets
             title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate5m{sloth_id=\"network-requests\"\
-            , sloth_service=\"network\", sloth_slo=\"requests\"} > (14.4 * 0.005))\
-            \ without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate1h{sloth_id=\"\
-            network-requests\", sloth_service=\"network\", sloth_slo=\"requests\"\
-            } > (14.4 * 0.005)) without (sloth_window)\n)\nor\n(\n    max(slo:sli_error:ratio_rate30m{sloth_id=\"\
-            network-requests\", sloth_service=\"network\", sloth_slo=\"requests\"\
-            } > (6 * 0.005)) without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate6h{sloth_id=\"\
-            network-requests\", sloth_service=\"network\", sloth_slo=\"requests\"\
-            } > (6 * 0.005)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate5m{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (14.4 * 0.005)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1h{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (14.4 * 0.005)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate30m{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (6 * 0.005)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate6h{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (6 * 0.005)) without (sloth_window)
+            )
           labels:
             severity: critical
             slo: 'true'
@@ -209,15 +176,18 @@ spec:
             summary: High number of lost network packets
             title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate2h{sloth_id=\"network-requests\"\
-            , sloth_service=\"network\", sloth_slo=\"requests\"} > (3 * 0.005)) without\
-            \ (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate1d{sloth_id=\"\
-            network-requests\", sloth_service=\"network\", sloth_slo=\"requests\"\
-            } > (3 * 0.005)) without (sloth_window)\n)\nor\n(\n    max(slo:sli_error:ratio_rate6h{sloth_id=\"\
-            network-requests\", sloth_service=\"network\", sloth_slo=\"requests\"\
-            } > (1 * 0.005)) without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate3d{sloth_id=\"\
-            network-requests\", sloth_service=\"network\", sloth_slo=\"requests\"\
-            } > (1 * 0.005)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate2h{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (3 * 0.005)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1d{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (3 * 0.005)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate6h{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (1 * 0.005)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate3d{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (1 * 0.005)) without (sloth_window)
+            )
           labels:
             severity: warning
             slo: 'true'

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/storage.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/storage.yaml
@@ -9,106 +9,80 @@ spec:
   groups:
     - name: sloth-slo-sli-recordings-storage-csi-operations
       rules:
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[5m])))
-
+        - expr: |
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[5m])))
             /
-
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[5m])))
-
-            '
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
             sloth_slo: csi-operations
             sloth_window: 5m
           record: slo:sli_error:ratio_rate5m
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[30m])))
-
+        - expr: |
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[30m])))
             /
-
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[30m])))
-
-            '
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
             sloth_slo: csi-operations
             sloth_window: 30m
           record: slo:sli_error:ratio_rate30m
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[1h])))
-
+        - expr: |
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[1h])))
             /
-
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[1h])))
-
-            '
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
             sloth_slo: csi-operations
             sloth_window: 1h
           record: slo:sli_error:ratio_rate1h
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[2h])))
-
+        - expr: |
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[2h])))
             /
-
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[2h])))
-
-            '
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
             sloth_slo: csi-operations
             sloth_window: 2h
           record: slo:sli_error:ratio_rate2h
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[6h])))
-
+        - expr: |
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[6h])))
             /
-
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[6h])))
-
-            '
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
             sloth_slo: csi-operations
             sloth_window: 6h
           record: slo:sli_error:ratio_rate6h
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[1d])))
-
+        - expr: |
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[1d])))
             /
-
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[1d])))
-
-            '
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
             sloth_slo: csi-operations
             sloth_window: 1d
           record: slo:sli_error:ratio_rate1d
-        - expr: '(sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[3d])))
-
+        - expr: |
+            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[3d])))
             /
-
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[3d])))
-
-            '
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
             sloth_slo: csi-operations
             sloth_window: 3d
           record: slo:sli_error:ratio_rate3d
-        - expr: 'sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="storage-csi-operations",
-            sloth_service="storage", sloth_slo="csi-operations"}[30d])
-
+        - expr: |
+            sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"}[30d])
             / ignoring (sloth_window)
-
-            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="storage-csi-operations",
-            sloth_service="storage", sloth_slo="csi-operations"}[30d])
-
-            '
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"}[30d])
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
@@ -135,29 +109,19 @@ spec:
             sloth_service: storage
             sloth_slo: csi-operations
           record: slo:time_period:days
-        - expr: 'slo:sli_error:ratio_rate5m{sloth_id="storage-csi-operations", sloth_service="storage",
-            sloth_slo="csi-operations"}
-
+        - expr: |
+            slo:sli_error:ratio_rate5m{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="storage-csi-operations", sloth_service="storage",
-            sloth_slo="csi-operations"}
-
-            '
+            slo:error_budget:ratio{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"}
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
             sloth_slo: csi-operations
           record: slo:current_burn_rate:ratio
-        - expr: 'slo:sli_error:ratio_rate30d{sloth_id="storage-csi-operations", sloth_service="storage",
-            sloth_slo="csi-operations"}
-
+        - expr: |
+            slo:sli_error:ratio_rate30d{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="storage-csi-operations", sloth_service="storage",
-            sloth_slo="csi-operations"}
-
-            '
+            slo:error_budget:ratio{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"}
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
@@ -188,15 +152,18 @@ spec:
             summary: High storage operation error rate
             title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate5m{sloth_id=\"storage-csi-operations\"\
-            , sloth_service=\"storage\", sloth_slo=\"csi-operations\"} > (14.4 * 0.005))\
-            \ without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate1h{sloth_id=\"\
-            storage-csi-operations\", sloth_service=\"storage\", sloth_slo=\"csi-operations\"\
-            } > (14.4 * 0.005)) without (sloth_window)\n)\nor\n(\n    max(slo:sli_error:ratio_rate30m{sloth_id=\"\
-            storage-csi-operations\", sloth_service=\"storage\", sloth_slo=\"csi-operations\"\
-            } > (6 * 0.005)) without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate6h{sloth_id=\"\
-            storage-csi-operations\", sloth_service=\"storage\", sloth_slo=\"csi-operations\"\
-            } > (6 * 0.005)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate5m{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"} > (14.4 * 0.005)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1h{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"} > (14.4 * 0.005)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate30m{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"} > (6 * 0.005)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate6h{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"} > (6 * 0.005)) without (sloth_window)
+            )
           labels:
             severity: critical
             slo: 'true'
@@ -209,15 +176,18 @@ spec:
             summary: High storage operation error rate
             title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate2h{sloth_id=\"storage-csi-operations\"\
-            , sloth_service=\"storage\", sloth_slo=\"csi-operations\"} > (3 * 0.005))\
-            \ without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate1d{sloth_id=\"\
-            storage-csi-operations\", sloth_service=\"storage\", sloth_slo=\"csi-operations\"\
-            } > (3 * 0.005)) without (sloth_window)\n)\nor\n(\n    max(slo:sli_error:ratio_rate6h{sloth_id=\"\
-            storage-csi-operations\", sloth_service=\"storage\", sloth_slo=\"csi-operations\"\
-            } > (1 * 0.005)) without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate3d{sloth_id=\"\
-            storage-csi-operations\", sloth_service=\"storage\", sloth_slo=\"csi-operations\"\
-            } > (1 * 0.005)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate2h{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"} > (3 * 0.005)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1d{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"} > (3 * 0.005)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate6h{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"} > (1 * 0.005)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate3d{sloth_id="storage-csi-operations", sloth_service="storage", sloth_slo="csi-operations"} > (1 * 0.005)) without (sloth_window)
+            )
           labels:
             severity: warning
             slo: 'true'

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/workload-schedulability.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/workload-schedulability.yaml
@@ -9,106 +9,80 @@ spec:
   groups:
     - name: sloth-slo-sli-recordings-workload-schedulability-canary
       rules:
-        - expr: '(sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[5m])))
-
+        - expr: |
+            (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[5m])))
             /
-
             (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos"}[5m])))
-
-            '
           labels:
             sloth_id: workload-schedulability-canary
             sloth_service: workload-schedulability
             sloth_slo: canary
             sloth_window: 5m
           record: slo:sli_error:ratio_rate5m
-        - expr: '(sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[30m])))
-
+        - expr: |
+            (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[30m])))
             /
-
             (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos"}[30m])))
-
-            '
           labels:
             sloth_id: workload-schedulability-canary
             sloth_service: workload-schedulability
             sloth_slo: canary
             sloth_window: 30m
           record: slo:sli_error:ratio_rate30m
-        - expr: '(sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[1h])))
-
+        - expr: |
+            (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[1h])))
             /
-
             (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos"}[1h])))
-
-            '
           labels:
             sloth_id: workload-schedulability-canary
             sloth_service: workload-schedulability
             sloth_slo: canary
             sloth_window: 1h
           record: slo:sli_error:ratio_rate1h
-        - expr: '(sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[2h])))
-
+        - expr: |
+            (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[2h])))
             /
-
             (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos"}[2h])))
-
-            '
           labels:
             sloth_id: workload-schedulability-canary
             sloth_service: workload-schedulability
             sloth_slo: canary
             sloth_window: 2h
           record: slo:sli_error:ratio_rate2h
-        - expr: '(sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[6h])))
-
+        - expr: |
+            (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[6h])))
             /
-
             (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos"}[6h])))
-
-            '
           labels:
             sloth_id: workload-schedulability-canary
             sloth_service: workload-schedulability
             sloth_slo: canary
             sloth_window: 6h
           record: slo:sli_error:ratio_rate6h
-        - expr: '(sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[1d])))
-
+        - expr: |
+            (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[1d])))
             /
-
             (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos"}[1d])))
-
-            '
           labels:
             sloth_id: workload-schedulability-canary
             sloth_service: workload-schedulability
             sloth_slo: canary
             sloth_window: 1d
           record: slo:sli_error:ratio_rate1d
-        - expr: '(sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[3d])))
-
+        - expr: |
+            (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos",reason="timed_out"}[3d])))
             /
-
             (sum by (name) (rate(scheduler_canary_pod_until_completed_seconds_count{exported_namespace="appuio-openshift4-slos"}[3d])))
-
-            '
           labels:
             sloth_id: workload-schedulability-canary
             sloth_service: workload-schedulability
             sloth_slo: canary
             sloth_window: 3d
           record: slo:sli_error:ratio_rate3d
-        - expr: 'sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="workload-schedulability-canary",
-            sloth_service="workload-schedulability", sloth_slo="canary"}[30d])
-
+        - expr: |
+            sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"}[30d])
             / ignoring (sloth_window)
-
-            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="workload-schedulability-canary",
-            sloth_service="workload-schedulability", sloth_slo="canary"}[30d])
-
-            '
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"}[30d])
           labels:
             sloth_id: workload-schedulability-canary
             sloth_service: workload-schedulability
@@ -135,29 +109,19 @@ spec:
             sloth_service: workload-schedulability
             sloth_slo: canary
           record: slo:time_period:days
-        - expr: 'slo:sli_error:ratio_rate5m{sloth_id="workload-schedulability-canary",
-            sloth_service="workload-schedulability", sloth_slo="canary"}
-
+        - expr: |
+            slo:sli_error:ratio_rate5m{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability",
-            sloth_slo="canary"}
-
-            '
+            slo:error_budget:ratio{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"}
           labels:
             sloth_id: workload-schedulability-canary
             sloth_service: workload-schedulability
             sloth_slo: canary
           record: slo:current_burn_rate:ratio
-        - expr: 'slo:sli_error:ratio_rate30d{sloth_id="workload-schedulability-canary",
-            sloth_service="workload-schedulability", sloth_slo="canary"}
-
+        - expr: |
+            slo:sli_error:ratio_rate30d{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"}
             / on(sloth_id, sloth_slo, sloth_service) group_left
-
-            slo:error_budget:ratio{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability",
-            sloth_slo="canary"}
-
-            '
+            slo:error_budget:ratio{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"}
           labels:
             sloth_id: workload-schedulability-canary
             sloth_service: workload-schedulability
@@ -188,16 +152,18 @@ spec:
             summary: Canary workloads time out.
             title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate5m{sloth_id=\"workload-schedulability-canary\"\
-            , sloth_service=\"workload-schedulability\", sloth_slo=\"canary\"} > (14.4\
-            \ * 0.0025)) without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate1h{sloth_id=\"\
-            workload-schedulability-canary\", sloth_service=\"workload-schedulability\"\
-            , sloth_slo=\"canary\"} > (14.4 * 0.0025)) without (sloth_window)\n)\n\
-            or\n(\n    max(slo:sli_error:ratio_rate30m{sloth_id=\"workload-schedulability-canary\"\
-            , sloth_service=\"workload-schedulability\", sloth_slo=\"canary\"} > (6\
-            \ * 0.0025)) without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate6h{sloth_id=\"\
-            workload-schedulability-canary\", sloth_service=\"workload-schedulability\"\
-            , sloth_slo=\"canary\"} > (6 * 0.0025)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate5m{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"} > (14.4 * 0.0025)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1h{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"} > (14.4 * 0.0025)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate30m{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"} > (6 * 0.0025)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate6h{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"} > (6 * 0.0025)) without (sloth_window)
+            )
           labels:
             severity: critical
             slo: 'true'
@@ -210,16 +176,18 @@ spec:
             summary: Canary workloads time out.
             title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
               budget burn rate is too fast.
-          expr: "(\n    max(slo:sli_error:ratio_rate2h{sloth_id=\"workload-schedulability-canary\"\
-            , sloth_service=\"workload-schedulability\", sloth_slo=\"canary\"} > (3\
-            \ * 0.0025)) without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate1d{sloth_id=\"\
-            workload-schedulability-canary\", sloth_service=\"workload-schedulability\"\
-            , sloth_slo=\"canary\"} > (3 * 0.0025)) without (sloth_window)\n)\nor\n\
-            (\n    max(slo:sli_error:ratio_rate6h{sloth_id=\"workload-schedulability-canary\"\
-            , sloth_service=\"workload-schedulability\", sloth_slo=\"canary\"} > (1\
-            \ * 0.0025)) without (sloth_window)\n    and\n    max(slo:sli_error:ratio_rate3d{sloth_id=\"\
-            workload-schedulability-canary\", sloth_service=\"workload-schedulability\"\
-            , sloth_slo=\"canary\"} > (1 * 0.0025)) without (sloth_window)\n)\n"
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate2h{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"} > (3 * 0.0025)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1d{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"} > (3 * 0.0025)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate6h{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"} > (1 * 0.0025)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate3d{sloth_id="workload-schedulability-canary", sloth_service="workload-schedulability", sloth_slo="canary"} > (1 * 0.0025)) without (sloth_window)
+            )
           labels:
             severity: warning
             slo: 'true'


### PR DESCRIPTION
As it turns out, the parameter isn't called what the documentation says it's called.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
