### PR TITLE
Increase blackbox-exporter memory limit to 100Mi

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -84,7 +84,7 @@ parameters:
         resources:
           limits:
             cpu: '20m'
-            memory: '40Mi'
+            memory: '100Mi'
           requests:
             cpu: '10m'
             memory: '20Mi'

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/20_blackbox_exporter_deploy.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/20_blackbox_exporter_deploy.yaml
@@ -55,7 +55,7 @@ spec:
           resources:
             limits:
               cpu: 20m
-              memory: 40Mi
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi


### PR DESCRIPTION
We've seen blackbox-exporter OOM kills with the previous memory limit of 40Mi on some clusters. Since increasing the memory limit doesn't change scheduling behavior, we go ahead and increase the default limit in the component defaults rather than adjusting it on individual clusters.

When the blackbox-exporter is OOM-killed, it's possible that we get spurious alerts for the ApiServer canary SLO, if one probe is missed due to the pod restart.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
