### PR TITLE
Guard against division by zero in storage SLO

### DIFF
--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/storage.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/storage.yaml
@@ -12,7 +12,7 @@ spec:
         - expr: |
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[5m])))
             /
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[5m])))
+            ((sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[5m])) > 0) or on() vector(1))
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
@@ -22,7 +22,7 @@ spec:
         - expr: |
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[30m])))
             /
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[30m])))
+            ((sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[30m])) > 0) or on() vector(1))
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
@@ -32,7 +32,7 @@ spec:
         - expr: |
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[1h])))
             /
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[1h])))
+            ((sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[1h])) > 0) or on() vector(1))
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
@@ -42,7 +42,7 @@ spec:
         - expr: |
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[2h])))
             /
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[2h])))
+            ((sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[2h])) > 0) or on() vector(1))
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
@@ -52,7 +52,7 @@ spec:
         - expr: |
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[6h])))
             /
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[6h])))
+            ((sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[6h])) > 0) or on() vector(1))
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
@@ -62,7 +62,7 @@ spec:
         - expr: |
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[1d])))
             /
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[1d])))
+            ((sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[1d])) > 0) or on() vector(1))
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage
@@ -72,7 +72,7 @@ spec:
         - expr: |
             (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+",status="fail-unknown"}[3d])))
             /
-            (sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[3d])))
+            ((sum(rate(storage_operation_duration_seconds_count{volume_plugin=~"kubernetes.io/csi.+",operation_name=~".+"}[3d])) > 0) or on() vector(1))
           labels:
             sloth_id: storage-csi-operations
             sloth_service: storage


### PR DESCRIPTION
On some clusters which have very little workload churn, there may be time windows in which there are 0 storage operations. The current `total_query` will evaluate to 0 in such a time window, leading to a division by zero for the SLO itself, which causes spurious alerts.

This commit adjusts the `total_query` to guard against this case by wrapping the previous expression with `(expr > 0) or on() vector(1)` which evaluates to `expr` if the expression results in > 0 and to 1 otherwise.

This removes the possibility of the SLO evaluating to NaN due to dividing by zero. Note that we can safely use `vector(1)` in the guard, as there can't be any failed storage operations if there's no storage operations at all. Therefore, if we divide by `vector(1)`, the expression always reduces to 0/1.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
