### PR TITLE
Fix scheduler-canary-controller deployed when disabled

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "fc8ae18a6798d5b232442630883e5ec9b8636d09",
+  "commit": "dcae06138d227340acb8056d0d031f32d75c09b5",
   "checkout": "main",
   "context": {
     "cookiecutter": {
       "name": "openshift4-slos",
       "slug": "openshift4-slos",
       "parameter_key": "openshift4_slos",
-      "test_cases": "defaults",
+      "test_cases": "defaults network-only",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - network-only
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -48,6 +49,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - network-only
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml
+test_instances = tests/defaults.yml tests/network-only.yml

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -121,8 +121,8 @@ local canary = kube._Object('monitoring.appuio.io/v1beta1', 'SchedulerCanary', '
       },
     },
   },
-  '30_canaryImageStream': canaryImageStream,
-  '30_canary': canary,
+  [if params.canary_scheduler_controller.enabled then '30_canaryImageStream']: canaryImageStream,
+  [if params.canary_scheduler_controller.enabled then '30_canary']: canary,
 }
 + blackbox.deployment
 + blackbox.probes

--- a/tests/golden/network-only/openshift4-slos/openshift4-slos/00_namespace.yaml
+++ b/tests/golden/network-only/openshift4-slos/openshift4-slos/00_namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+  labels:
+    name: appuio-openshift4-slos
+    openshift.io/cluster-monitoring: 'true'
+  name: appuio-openshift4-slos

--- a/tests/golden/network-only/openshift4-slos/openshift4-slos/10_network_canary_namespace.yaml
+++ b/tests/golden/network-only/openshift4-slos/openshift4-slos/10_network_canary_namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: node-role.kubernetes.io/worker=
+  labels:
+    name: appuio-network-canary
+    openshift.io/cluster-monitoring: 'true'
+  name: appuio-network-canary

--- a/tests/golden/network-only/openshift4-slos/openshift4-slos/20_network_canary_daemonset.yaml
+++ b/tests/golden/network-only/openshift4-slos/openshift4-slos/20_network_canary_daemonset.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations: {}
+  labels:
+    name: network-canary
+  name: network-canary
+  namespace: appuio-network-canary
+spec:
+  selector:
+    matchLabels:
+      name: network-canary
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        name: network-canary
+    spec:
+      containers:
+        - args:
+            - /canary
+            - --ping-dns=network-canary
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          image: ghcr.io/appuio/network-canary:v0.2.0
+          imagePullPolicy: IfNotPresent
+          name: canary
+          ports:
+            - containerPort: 2112
+              name: metrics
+          resources:
+            limits:
+              memory: 40Mi
+            requests:
+              cpu: 1m
+              memory: 20Mi
+          stdin: false
+          tty: false
+          volumeMounts: []
+      imagePullSecrets: []
+      initContainers: []
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+        - key: storagenode
+          operator: Exists
+      volumes: []
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/tests/golden/network-only/openshift4-slos/openshift4-slos/20_network_canary_service.yaml
+++ b/tests/golden/network-only/openshift4-slos/openshift4-slos/20_network_canary_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    name: network-canary
+  name: network-canary
+  namespace: appuio-network-canary
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 2112
+      targetPort: 2112
+  selector:
+    name: network-canary
+  type: ClusterIP

--- a/tests/golden/network-only/openshift4-slos/openshift4-slos/20_network_canary_servicemonitor.yaml
+++ b/tests/golden/network-only/openshift4-slos/openshift4-slos/20_network_canary_servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: network-canary
+  name: network-canary
+  namespace: appuio-network-canary
+spec:
+  endpoints:
+    - port: metrics
+  selector:
+    matchLabels:
+      name: network-canary

--- a/tests/golden/network-only/openshift4-slos/openshift4-slos/network.yaml
+++ b/tests/golden/network-only/openshift4-slos/openshift4-slos/network.yaml
@@ -1,0 +1,196 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: network
+  name: network
+spec:
+  groups:
+    - name: sloth-slo-sli-recordings-network-requests
+      rules:
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[5m])))
+            /
+            (sum(rate(ping_rtt_seconds_count[5m])))
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+            sloth_window: 5m
+          record: slo:sli_error:ratio_rate5m
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[30m])))
+            /
+            (sum(rate(ping_rtt_seconds_count[30m])))
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+            sloth_window: 30m
+          record: slo:sli_error:ratio_rate30m
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[1h])))
+            /
+            (sum(rate(ping_rtt_seconds_count[1h])))
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+            sloth_window: 1h
+          record: slo:sli_error:ratio_rate1h
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[2h])))
+            /
+            (sum(rate(ping_rtt_seconds_count[2h])))
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+            sloth_window: 2h
+          record: slo:sli_error:ratio_rate2h
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[6h])))
+            /
+            (sum(rate(ping_rtt_seconds_count[6h])))
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+            sloth_window: 6h
+          record: slo:sli_error:ratio_rate6h
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[1d])))
+            /
+            (sum(rate(ping_rtt_seconds_count[1d])))
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+            sloth_window: 1d
+          record: slo:sli_error:ratio_rate1d
+        - expr: |
+            (sum(rate(ping_rtt_seconds_count{reason="lost"}[3d])))
+            /
+            (sum(rate(ping_rtt_seconds_count[3d])))
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+            sloth_window: 3d
+          record: slo:sli_error:ratio_rate3d
+        - expr: |
+            sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"}[30d])
+            / ignoring (sloth_window)
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"}[30d])
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+            sloth_window: 30d
+          record: slo:sli_error:ratio_rate30d
+    - name: sloth-slo-meta-recordings-network-requests
+      rules:
+        - expr: vector(0.995)
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+          record: slo:objective:ratio
+        - expr: vector(1-0.995)
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+          record: slo:error_budget:ratio
+        - expr: vector(30)
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+          record: slo:time_period:days
+        - expr: |
+            slo:sli_error:ratio_rate5m{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"}
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+            slo:error_budget:ratio{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"}
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+          record: slo:current_burn_rate:ratio
+        - expr: |
+            slo:sli_error:ratio_rate30d{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"}
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+            slo:error_budget:ratio{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"}
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+          record: slo:period_burn_rate:ratio
+        - expr: 1 - slo:period_burn_rate:ratio{sloth_id="network-requests", sloth_service="network",
+            sloth_slo="requests"}
+          labels:
+            sloth_id: network-requests
+            sloth_service: network
+            sloth_slo: requests
+          record: slo:period_error_budget_remaining:ratio
+        - expr: vector(1)
+          labels:
+            sloth_id: network-requests
+            sloth_mode: cli-gen-prom
+            sloth_objective: '99.5'
+            sloth_service: network
+            sloth_slo: requests
+            sloth_spec: prometheus/v1
+            sloth_version: v0.11.0
+          record: sloth_slo_info
+    - name: sloth-slo-alerts-network-requests
+      rules:
+        - alert: SLO_NetworkPacketLossHigh
+          annotations:
+            runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/network.html#requests
+            summary: High number of lost network packets
+            title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate5m{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (14.4 * 0.005)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1h{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (14.4 * 0.005)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate30m{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (6 * 0.005)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate6h{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (6 * 0.005)) without (sloth_window)
+            )
+          labels:
+            severity: critical
+            slo: 'true'
+            sloth_severity: page
+            syn: 'true'
+            syn_component: openshift4-slos
+        - alert: SLO_NetworkPacketLossHigh
+          annotations:
+            runbook_url: https://hub.syn.tools/openshift4-slos/runbooks/network.html#requests
+            summary: High number of lost network packets
+            title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate2h{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (3 * 0.005)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1d{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (3 * 0.005)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate6h{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (1 * 0.005)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate3d{sloth_id="network-requests", sloth_service="network", sloth_slo="requests"} > (1 * 0.005)) without (sloth_window)
+            )
+          labels:
+            severity: warning
+            slo: 'true'
+            sloth_severity: ticket
+            syn: 'true'
+            syn_component: openshift4-slos

--- a/tests/network-only.yml
+++ b/tests/network-only.yml
@@ -1,0 +1,3 @@
+# Overwrite parameters here
+
+# parameters: {...}

--- a/tests/network-only.yml
+++ b/tests/network-only.yml
@@ -1,3 +1,28 @@
 # Overwrite parameters here
 
-# parameters: {...}
+parameters:
+  openshift4_slos:
+    slos:
+      storage:
+        csi-operations:
+          enabled: false
+      ingress:
+        canary:
+          enabled: false
+      kubernetes_api:
+        requests:
+          enabled: false
+        canary:
+          enabled: false
+      workload-schedulability:
+        canary:
+          enabled: false
+      network:
+        canary:
+          enabled: true
+
+    blackbox_exporter:
+      enabled: false
+
+    canary_scheduler_controller:
+      enabled: false


### PR DESCRIPTION
When workload-schedulability slos are disabled, some artefacts are still getting deployed.  
This causes errors, as used CRD are not installed.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
