### PR TITLE
Support nodeSelector for network-canary on non-ocp clusters

### DIFF
--- a/component/network-canary.libsonnet
+++ b/component/network-canary.libsonnet
@@ -8,6 +8,9 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift4_slos;
 
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+local splitNodeSelector = std.split(params.network_canary.nodeselector, '=');
+
 local ns = kube.Namespace(params.network_canary.namespace) {
   metadata+: {
     annotations+: {
@@ -44,6 +47,9 @@ local ds = kube.DaemonSet('network-canary') {
               },
             },
           },
+        },
+        [if !isOpenshift then 'nodeSelector']: {
+          [splitNodeSelector[0]]: splitNodeSelector[1],
         },
         tolerations: std.objectValues(params.network_canary.tolerations),
       },

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/20_network_canary_daemonset.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/20_network_canary_daemonset.yaml
@@ -42,6 +42,8 @@ spec:
           volumeMounts: []
       imagePullSecrets: []
       initContainers: []
+      nodeSelector:
+        node-role.kubernetes.io/worker: ''
       terminationGracePeriodSeconds: 30
       tolerations:
         - effect: NoSchedule

--- a/tests/golden/network-only/openshift4-slos/openshift4-slos/10_network_canary_namespace.yaml
+++ b/tests/golden/network-only/openshift4-slos/openshift4-slos/10_network_canary_namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    openshift.io/node-selector: node-role.kubernetes.io/worker=
+    openshift.io/node-selector: node-role.kubernetes.io/worker=true
   labels:
     name: appuio-network-canary
     openshift.io/cluster-monitoring: 'true'

--- a/tests/golden/network-only/openshift4-slos/openshift4-slos/20_network_canary_daemonset.yaml
+++ b/tests/golden/network-only/openshift4-slos/openshift4-slos/20_network_canary_daemonset.yaml
@@ -42,6 +42,8 @@ spec:
           volumeMounts: []
       imagePullSecrets: []
       initContainers: []
+      nodeSelector:
+        node-role.kubernetes.io/worker: 'true'
       terminationGracePeriodSeconds: 30
       tolerations:
         - effect: NoSchedule

--- a/tests/network-only.yml
+++ b/tests/network-only.yml
@@ -26,3 +26,6 @@ parameters:
 
     canary_scheduler_controller:
       enabled: false
+
+    network_canary:
+      nodeselector: node-role.kubernetes.io/worker=true


### PR DESCRIPTION
Setting the network-canary nodeSelector does not support non-OpenShift clusters. This will properly set the correct nodeSelector on the DaemonSet when not in OpenShift environment.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
