### PR TITLE
Fix missing namespace labels for non-openshift clusters

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -12,6 +12,8 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift4_slos;
 
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+
 
 // Define outputs below
 local mergeSpec = function(name, spec)
@@ -118,6 +120,7 @@ local canary = kube._Object('monitoring.appuio.io/v1beta1', 'SchedulerCanary', '
       },
       labels+: {
         'openshift.io/cluster-monitoring': 'true',
+        [if !isOpenshift then 'monitoring.syn.tools/infra']: 'true',
       },
     },
   },

--- a/component/network-canary.libsonnet
+++ b/component/network-canary.libsonnet
@@ -18,6 +18,7 @@ local ns = kube.Namespace(params.network_canary.namespace) {
     },
     labels+: {
       'openshift.io/cluster-monitoring': 'true',
+      [if !isOpenshift then 'monitoring.syn.tools/infra']: 'true',
     },
   },
 };

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/00_namespace.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/00_namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     openshift.io/node-selector: ''
   labels:
+    monitoring.syn.tools/infra: 'true'
     name: appuio-openshift4-slos
     openshift.io/cluster-monitoring: 'true'
   name: appuio-openshift4-slos

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/10_network_canary_namespace.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/10_network_canary_namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     openshift.io/node-selector: node-role.kubernetes.io/worker=
   labels:
+    monitoring.syn.tools/infra: 'true'
     name: appuio-network-canary
     openshift.io/cluster-monitoring: 'true'
   name: appuio-network-canary

--- a/tests/golden/network-only/openshift4-slos/openshift4-slos/00_namespace.yaml
+++ b/tests/golden/network-only/openshift4-slos/openshift4-slos/00_namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     openshift.io/node-selector: ''
   labels:
+    monitoring.syn.tools/infra: 'true'
     name: appuio-openshift4-slos
     openshift.io/cluster-monitoring: 'true'
   name: appuio-openshift4-slos

--- a/tests/golden/network-only/openshift4-slos/openshift4-slos/10_network_canary_namespace.yaml
+++ b/tests/golden/network-only/openshift4-slos/openshift4-slos/10_network_canary_namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     openshift.io/node-selector: node-role.kubernetes.io/worker=true
   labels:
+    monitoring.syn.tools/infra: 'true'
     name: appuio-network-canary
     openshift.io/cluster-monitoring: 'true'
   name: appuio-network-canary


### PR DESCRIPTION
When deploying on non-openshift clusters the namespaces need a label for prometheus to be scraped.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
