### PR TITLE
Fix missing prometheusrule labels for non-openshift clusters

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -18,7 +18,11 @@ local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift
 // Define outputs below
 local mergeSpec = function(name, spec)
   local slothRendered = std.parseJson(kap.yaml_load('%s/sloth-output/%s.yaml' % [ inv.parameters._base_directory, name ]));
-  local metadata = com.makeMergeable(std.get(spec, 'metadata', {}));
+  local metadata = com.makeMergeable(
+    std.get(spec, 'metadata', {}) + {
+      [if !isOpenshift then 'labels']: { 'monitoring.syn.tools/enabled': 'true' },
+    },
+  );
   local extra_rules = std.get(spec, 'extra_rules', []);
   kube._Object('monitoring.coreos.com/v1', 'PrometheusRule', kube.hyphenate(name)) {
     metadata+: metadata,

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,6 +1,8 @@
 # Overwrite parameters here
 
 parameters:
+  facts:
+    distribution: openshift4
   openshift:
     appsDomain: apps.foo.example.com
   openshift4_slos:

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/00_namespace.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/00_namespace.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     openshift.io/node-selector: ''
   labels:
-    monitoring.syn.tools/infra: 'true'
     name: appuio-openshift4-slos
     openshift.io/cluster-monitoring: 'true'
   name: appuio-openshift4-slos

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/10_network_canary_namespace.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/10_network_canary_namespace.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     openshift.io/node-selector: node-role.kubernetes.io/worker=
   labels:
-    monitoring.syn.tools/infra: 'true'
     name: appuio-network-canary
     openshift.io/cluster-monitoring: 'true'
   name: appuio-network-canary

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/20_network_canary_daemonset.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/20_network_canary_daemonset.yaml
@@ -42,8 +42,6 @@ spec:
           volumeMounts: []
       imagePullSecrets: []
       initContainers: []
-      nodeSelector:
-        node-role.kubernetes.io/worker: ''
       terminationGracePeriodSeconds: 30
       tolerations:
         - effect: NoSchedule

--- a/tests/golden/network-only/openshift4-slos/openshift4-slos/network.yaml
+++ b/tests/golden/network-only/openshift4-slos/openshift4-slos/network.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   annotations: {}
   labels:
+    monitoring.syn.tools/enabled: 'true'
     name: network
   name: network
 spec:


### PR DESCRIPTION
When deploying on non-openshift clusters the prometheusrules need a label for prometheus to be scraped.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
