### PR TITLE
Allow root-less pings for network-canary on non-OpenShift

### DIFF
--- a/component/network-canary.libsonnet
+++ b/component/network-canary.libsonnet
@@ -52,6 +52,14 @@ local ds = kube.DaemonSet('network-canary') {
         [if !isOpenshift then 'nodeSelector']: {
           [splitNodeSelector[0]]: splitNodeSelector[1],
         },
+        [if !isOpenshift then 'securityContext']: {
+          // on non-OCP (tested on RKE2/Ubuntu) we need to set the rootless
+          // ping sysctl.
+          sysctls: [ {
+            name: 'net.ipv4.ping_group_range',
+            value: '0 2147483647',
+          } ],
+        },
         tolerations: std.objectValues(params.network_canary.tolerations),
       },
     },

--- a/tests/golden/network-only/openshift4-slos/openshift4-slos/20_network_canary_daemonset.yaml
+++ b/tests/golden/network-only/openshift4-slos/openshift4-slos/20_network_canary_daemonset.yaml
@@ -44,6 +44,10 @@ spec:
       initContainers: []
       nodeSelector:
         node-role.kubernetes.io/worker: 'true'
+      securityContext:
+        sysctls:
+          - name: net.ipv4.ping_group_range
+            value: 0 2147483647
       terminationGracePeriodSeconds: 30
       tolerations:
         - effect: NoSchedule


### PR DESCRIPTION
As mentioned in https://github.com/appuio/network-canary#unprivileged-icmp, the network-canary uses unprivileged pings.

After searching for a while, I found that we need to set the mentioned sysctl on the pod for it to actually make a difference (it's enabled on the node).

From what I can see, this is not required on OpenShift 4 for some reason, so I'm just setting it for non-OpenShift.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
