### PR TITLE
Fix ingress error ratio query to only consider the canary route for the cluster's `appsDomain`

### DIFF
--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/ingress.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/ingress.yaml
@@ -10,49 +10,49 @@ spec:
   groups:
     - name: sloth-slo-sli-recordings-ingress-canary
       rules:
-        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[5m]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance{host="canary-openshift-ingress-canary.apps.foo.example.com"}[5m]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
             sloth_window: 5m
           record: slo:sli_error:ratio_rate5m
-        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[30m]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance{host="canary-openshift-ingress-canary.apps.foo.example.com"}[30m]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
             sloth_window: 30m
           record: slo:sli_error:ratio_rate30m
-        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[1h]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance{host="canary-openshift-ingress-canary.apps.foo.example.com"}[1h]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
             sloth_window: 1h
           record: slo:sli_error:ratio_rate1h
-        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[2h]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance{host="canary-openshift-ingress-canary.apps.foo.example.com"}[2h]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
             sloth_window: 2h
           record: slo:sli_error:ratio_rate2h
-        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[6h]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance{host="canary-openshift-ingress-canary.apps.foo.example.com"}[6h]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
             sloth_window: 6h
           record: slo:sli_error:ratio_rate6h
-        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[1d]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance{host="canary-openshift-ingress-canary.apps.foo.example.com"}[1d]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress
             sloth_slo: canary
             sloth_window: 1d
           record: slo:sli_error:ratio_rate1d
-        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance[3d]))
+        - expr: (1 - avg_over_time(appuio_ocp4_slo:ingress_canary_route_reachable:no_instance{host="canary-openshift-ingress-canary.apps.foo.example.com"}[3d]))
           labels:
             sloth_id: ingress-canary
             sloth_service: ingress


### PR DESCRIPTION
This is required to support changing a cluster's `appsDomain` after the initial setup.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
