### PR TITLE
Fix CRD sync error caused by big `last-applied-configuration` annotation

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -194,3 +194,13 @@ parameters:
                   spec:
                     affinity:
                       nodeAffinity: ${openshift4_slos:controller_node_affinity}
+          # Use replace for CRDs to avoid errors because the
+          # last-applied-configuration annotation gets too big.
+          - patch: |-
+              $patch: merge
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: schedulercanaries.monitoring.appuio.io
+                annotations:
+                  argocd.argoproj.io/sync-options: Replace=true

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/scheduler-canary-deployment/apiextensions.k8s.io_v1_customresourcedefinition_schedulercanaries.monitoring.appuio.io.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/scheduler-canary-deployment/apiextensions.k8s.io_v1_customresourcedefinition_schedulercanaries.monitoring.appuio.io.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Replace=true
     controller-gen.kubebuilder.io/version: v0.15.0
   name: schedulercanaries.monitoring.appuio.io
 spec:


### PR DESCRIPTION


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
