### PR TITLE
Stop canary pods stopping downscaling.

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -69,7 +69,11 @@ local canary = kube._Object('monitoring.appuio.io/v1beta1', 'SchedulerCanary', '
     interval: sliConfig.podStartInterval,
     maxPodCompletionTimeout: sliConfig.overallPodTimeout,
     podTemplate: {
-      metadata: {},
+      metadata: {
+        annotations: {
+          'cluster-autoscaler.kubernetes.io/safe-to-evict': 'true',
+        },
+      },
       spec: {
         affinity: {
           nodeAffinity: params.canary_node_affinity,
@@ -129,7 +133,11 @@ local storageCanaries = std.flattenArrays(std.filterMap(
           maxPodCompletionTimeout: p.maxPodCompletionTimeout,
           forbidParallelRuns: true,
           podTemplate: {
-            metadata: {},
+            metadata: {
+              annotations: {
+                'cluster-autoscaler.kubernetes.io/safe-to-evict': 'true',
+              },
+            },
             spec: {
               affinity: {
                 nodeAffinity: params.canary_node_affinity,

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/30_canary.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/30_canary.yaml
@@ -10,7 +10,9 @@ spec:
   interval: 1m
   maxPodCompletionTimeout: 3m
   podTemplate:
-    metadata: {}
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       affinity:
         nodeAffinity:

--- a/tests/golden/defaults/openshift4-slos/openshift4-slos/32_storageCanary.yaml
+++ b/tests/golden/defaults/openshift4-slos/openshift4-slos/32_storageCanary.yaml
@@ -26,7 +26,9 @@ spec:
   interval: 1m
   maxPodCompletionTimeout: 3m
   podTemplate:
-    metadata: {}
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       affinity:
         nodeAffinity:
@@ -93,7 +95,9 @@ spec:
   interval: 1m
   maxPodCompletionTimeout: 3m
   podTemplate:
-    metadata: {}
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       affinity:
         nodeAffinity:
@@ -160,7 +164,9 @@ spec:
   interval: 1m
   maxPodCompletionTimeout: 3m
   podTemplate:
-    metadata: {}
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       affinity:
         nodeAffinity:


### PR DESCRIPTION
The canary pods are seen as having no controller (deployment, ...) and thus block the removal of nodes. The problem is accentuated because they are usually scheduled on the least used node - which is also the node that would be downscaled.

As a follow-up we might want to update the controller scheduling those pods to be seen as a controller similarly to a deployment.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
